### PR TITLE
Add offer command

### DIFF
--- a/lambda/commands.js
+++ b/lambda/commands.js
@@ -34,6 +34,7 @@ exports.handler = async (event) => {
     stack: `Stack:\n- Terminal UI: React + Custom Command Handler\n- Hosting: S3 + CloudFront\n- Backend: Lambda + API Gateway\n- Data: DynamoDB\n- Infra as Code: Terraform\n- CI/CD: GitHub Actions\n- DNS: Route 53`,
     architecture: `Infrastructure Diagram:\n+---------------------+\n|       CI/CD         |\n|---------------------|\n|  GitHub Actions     |\n+----------+----------+\n           |\n           v\n+---------------------+\n|     S3 Bucket       |\n|  Static Website     |\n+----------+----------+\n           |\n           v\n+---------------------+\n|    CloudFront CDN   |\n+----+-----------+----+\n     |           |\n     v           v\n+----------+   +------------------+\n| Route 53 |   |   API Gateway    |\n+----------+   +---------+--------+\n                      |\n                      v\n                +-----------+\n                |  Lambda   |\n                +-----+-----+\n                      |\n                      v\n                +-----------+\n                | DynamoDB  |\n                +-----------+`,
     quote: '“Ship often. Think big. Stay sharp.” – J.L.',
+    offer: 'Offer command is handled client-side.',
     clear: '__CLEAR__',
     exit: 'Logging out...\nSession terminated.',
     'source code': 'Browse source: https://github.com/serversorcerer/cloud-resume-challenge'

--- a/website/index.html
+++ b/website/index.html
@@ -595,6 +595,7 @@
   // Terminal commands served by backend
   // Endpoint for Lambda-backed command processor
   const API_URL = 'https://4wmuu5rp71.execute-api.us-east-1.amazonaws.com/';
+  const OFFER_WEBHOOK = 'https://hooks.zapier.com/hooks/catch/23156361/2v4xduy/';
 
   const commandList = [
     'help',
@@ -620,6 +621,7 @@
     'source code'
     ,'joker mode'
     ,'professional mode'
+    ,'offer'
   ];
 
   const openCommands = {
@@ -629,6 +631,9 @@
     'email': 'mailto:joe@josephaleto.io',
     'source code': 'https://github.com/serversorcerer/cloud-resume-challenge'
   };
+
+  let offerState = null; // null | 'name' | 'email'
+  let offerData = { name: '', email: '' };
 
   async function executeCommand(cmd) {
     try {
@@ -718,6 +723,7 @@
     if (e.key === "Enter") {
       const input = terminalInput.value.trim();
       if (!input) return;
+      const cmdLower = input.toLowerCase();
       commandHistory.push(input);
       historyIndex = commandHistory.length;
       const output = document.createElement("div");
@@ -725,7 +731,83 @@
       terminalContent.appendChild(output);
       terminalSuggestion.style.display = "none";
 
-      const cmdLower = input.toLowerCase();
+      if (offerState) {
+        if (['clear','exit'].includes(cmdLower)) {
+          if (cmdLower === 'clear') {
+            const clrResp = await executeCommand('clear');
+            if (clrResp === "__CLEAR__") {
+              terminalContent.classList.add("terminal-fade");
+              setTimeout(() => {
+                terminalContent.innerHTML = "";
+                terminalContent.classList.remove("terminal-fade");
+              }, 500);
+            }
+          } else {
+            const cancelMsg = document.createElement('div');
+            cancelMsg.textContent = 'Offer cancelled.';
+            cancelMsg.style.color = '#33ff33';
+            terminalContent.appendChild(cancelMsg);
+          }
+          offerState = null;
+          terminalInput.value = "";
+          scrollToBottom();
+          return;
+        }
+
+        if (offerState === 'name') {
+          offerData.name = input;
+          const askEmail = document.createElement('div');
+          askEmail.textContent = "What's your email?";
+          askEmail.style.color = '#33ff33';
+          terminalContent.appendChild(askEmail);
+          offerState = 'email';
+          terminalInput.value = "";
+          scrollToBottom();
+          return;
+        } else if (offerState === 'email') {
+          offerData.email = input;
+          const emailRegex = /^\S+@\S+\.\S+$/;
+          if (!emailRegex.test(offerData.email)) {
+            const invalid = document.createElement('div');
+            invalid.textContent = "Invalid email format. Try again or type 'exit' to cancel.";
+            invalid.style.color = '#ff3333';
+            terminalContent.appendChild(invalid);
+            terminalInput.value = "";
+            scrollToBottom();
+            return;
+          }
+          try {
+            await fetch(OFFER_WEBHOOK, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ command: 'offer', name: offerData.name, email: offerData.email, time: new Date().toISOString() })
+            });
+          } catch (err) {
+            console.error(err);
+          }
+          const doneMsg = document.createElement('div');
+          doneMsg.textContent = '✅ Offer received — I\u2019ll follow up soon.';
+          doneMsg.style.color = '#33ff33';
+          terminalContent.appendChild(doneMsg);
+          offerState = null;
+          terminalInput.value = "";
+          scrollToBottom();
+          return;
+        }
+      }
+
+      if (cmdLower === 'offer') {
+        offerState = 'name';
+        offerData = { name: '', email: '' };
+        const askName = document.createElement('div');
+        askName.textContent = "What's your name?";
+        askName.style.color = '#33ff33';
+        terminalContent.appendChild(askName);
+        terminalInput.value = "";
+        scrollToBottom();
+        return;
+      }
+
       if (openCommands[cmdLower]) {
         window.open(openCommands[cmdLower], '_blank');
         const response = document.createElement('div');


### PR DESCRIPTION
## Summary
- implement new `offer` command for terminal UI
- collect name and email then post to Zapier webhook
- add client-side handling note in Lambda

## Testing
- `node -e "require('./lambda/commands.js'); console.log('lambda loaded')"`


------
https://chatgpt.com/codex/tasks/task_e_683a29b7c1b48330ab8d59cb87a43995