### PR TITLE
Implement offer forwarding via Lambda

### DIFF
--- a/lambda/commands.js
+++ b/lambda/commands.js
@@ -16,6 +16,26 @@ exports.handler = async (event) => {
 
   const command = (body.command || '').trim().toLowerCase();
 
+  if (command === 'offer') {
+    if (!body.name || !body.email) {
+      return { statusCode: 400, headers: HEADERS, body: 'Name and email required' };
+    }
+    const payload = { name: body.name, email: body.email, time: new Date().toISOString() };
+    console.log('Sending payload:', payload);
+    try {
+      const resp = await fetch('https://hooks.zapier.com/hooks/catch/23156361/2v4xduy/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      console.log('Zapier response status:', resp.status);
+    } catch (err) {
+      console.error('Error posting to Zapier', err);
+      return { statusCode: 500, headers: HEADERS, body: 'Failed to forward offer' };
+    }
+    return { statusCode: 200, headers: HEADERS, body: 'Offer forwarded' };
+  }
+
   const responses = {
     help: `Available Commands:\n--------------------\naws s3 ls           – list S3 buckets\nview counter        – fetch visitor count\nterraform apply     – apply infra (simulated)\nmotd                – welcome message\nwhoami              – user identity\nbio                 – about Joe Leto\nresume              – open resume PDF\nlinkedin            – LinkedIn profile\ngithub              – GitHub profile\nemail               – contact via email\nprojects            – list cloud projects\nstack               – show stack details\narchitecture        – show architecture diagram\nquote               – inspiration\nclear               – clear screen\nexit                – log out\nsource code         – browse source repo`,
     'aws s3 ls': '[bucket] josephaleto.io\n[bucket] resume-storage\n[bucket] inframirror-assets',
@@ -34,7 +54,6 @@ exports.handler = async (event) => {
     stack: `Stack:\n- Terminal UI: React + Custom Command Handler\n- Hosting: S3 + CloudFront\n- Backend: Lambda + API Gateway\n- Data: DynamoDB\n- Infra as Code: Terraform\n- CI/CD: GitHub Actions\n- DNS: Route 53`,
     architecture: `Infrastructure Diagram:\n+---------------------+\n|       CI/CD         |\n|---------------------|\n|  GitHub Actions     |\n+----------+----------+\n           |\n           v\n+---------------------+\n|     S3 Bucket       |\n|  Static Website     |\n+----------+----------+\n           |\n           v\n+---------------------+\n|    CloudFront CDN   |\n+----+-----------+----+\n     |           |\n     v           v\n+----------+   +------------------+\n| Route 53 |   |   API Gateway    |\n+----------+   +---------+--------+\n                      |\n                      v\n                +-----------+\n                |  Lambda   |\n                +-----+-----+\n                      |\n                      v\n                +-----------+\n                | DynamoDB  |\n                +-----------+`,
     quote: '“Ship often. Think big. Stay sharp.” – J.L.',
-    offer: 'Offer command is handled client-side.',
     clear: '__CLEAR__',
     exit: 'Logging out...\nSession terminated.',
     'source code': 'Browse source: https://github.com/serversorcerer/cloud-resume-challenge'

--- a/website/index.html
+++ b/website/index.html
@@ -595,7 +595,6 @@
   // Terminal commands served by backend
   // Endpoint for Lambda-backed command processor
   const API_URL = 'https://4wmuu5rp71.execute-api.us-east-1.amazonaws.com/';
-  const OFFER_WEBHOOK = 'https://hooks.zapier.com/hooks/catch/23156361/2v4xduy/';
 
   const commandList = [
     'help',
@@ -776,17 +775,19 @@
             scrollToBottom();
             return;
           }
-          // Add console.log before sending to webhook
-          console.log("Sending to webhook:", {
+          // Build payload and log before sending
+          const payload = {
+            command: 'offer',
             name: offerData.name,
             email: offerData.email,
             time: new Date().toISOString()
-          });
+          };
+          console.log("Sending payload:", payload);
           try {
-            await fetch(OFFER_WEBHOOK, {
+            await fetch(API_URL, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ command: 'offer', name: offerData.name, email: offerData.email, time: new Date().toISOString() })
+              body: JSON.stringify(payload)
             });
           } catch (err) {
             console.error(err);


### PR DESCRIPTION
## Summary
- forward `offer` requests from Lambda to Zapier instead of relying on the browser
- POST the offer data from the website to the existing API endpoint

## Testing
- `zip function.zip commands.js` *(generated a zip file)*
- `aws lambda update-function-code --function-name terminal-commands --zip-file fileb://function.zip` *(failed: `aws: command not found`)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683a3968a0c083309c8ed2bde214a41c