### PR TITLE
Restore API and offer flow

### DIFF
--- a/infra/modules/command_api/main.tf
+++ b/infra/modules/command_api/main.tf
@@ -60,6 +60,12 @@ resource "aws_apigatewayv2_route" "command" {
   target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
 }
 
+resource "aws_apigatewayv2_route" "options" {
+  api_id    = aws_apigatewayv2_api.api.id
+  route_key = "OPTIONS /"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+}
+
 resource "aws_apigatewayv2_stage" "default" {
   api_id      = aws_apigatewayv2_api.api.id
   name        = "$default"

--- a/website/index.html
+++ b/website/index.html
@@ -314,6 +314,14 @@
                       60% { background: #440000; color: #ff4e4e; opacity: 1;}
                       100% { background: none; color: #ff4e4e; opacity: 0;}
                     }
+                    .flash-success {
+                      animation: flashSuccess 1s ease;
+                    }
+                    @keyframes flashSuccess {
+                      0% { opacity: 0; }
+                      40% { opacity: 1; }
+                      100% { opacity: 0.85; }
+                    }
                     /* Tab suggestion style */
                     .terminal-suggestion {
                       color: #00ffff;
@@ -615,6 +623,7 @@
     'stack',
     'architecture',
     'quote',
+    'offer',
     'clear',
     'exit',
     'source code'
@@ -647,6 +656,8 @@
   // Command history
   let commandHistory = [];
   let historyIndex = -1;
+  let offerState = null; // null, 'name', or 'email'
+  let offerName = '';
 
   // Expand terminal on first keystroke in input
   let terminalExpanded = false;
@@ -726,6 +737,87 @@
       terminalSuggestion.style.display = "none";
 
       const cmdLower = input.toLowerCase();
+
+      if (offerState) {
+        if (cmdLower === 'clear' || cmdLower === 'exit') {
+          offerState = null;
+          offerName = '';
+          const resp = await executeCommand(cmdLower);
+          if (resp === "__CLEAR__") {
+            terminalContent.classList.add("terminal-fade");
+            setTimeout(() => {
+              terminalContent.innerHTML = "";
+              terminalContent.classList.remove("terminal-fade");
+            }, 500);
+          } else {
+            const r = document.createElement('div');
+            r.innerHTML = `<span style="color:#33ff33;">${resp}</span>`;
+            terminalContent.appendChild(r);
+          }
+          terminalInput.value = '';
+          scrollToBottom();
+          return;
+        }
+
+        if (offerState === 'name') {
+          offerName = input;
+          offerState = 'email';
+          const prompt = document.createElement('div');
+          prompt.textContent = 'Enter your email:';
+          prompt.style.color = '#33ff33';
+          terminalContent.appendChild(prompt);
+          terminalInput.value = '';
+          scrollToBottom();
+          return;
+        } else if (offerState === 'email') {
+          const email = input;
+          const valid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+          if (!valid) {
+            const err = document.createElement('div');
+            err.textContent = 'Invalid email. Try again:';
+            err.style.color = '#ff6666';
+            terminalContent.appendChild(err);
+            terminalInput.value = '';
+            scrollToBottom();
+            return;
+          }
+          offerState = null;
+          console.log('Sending payload:', { command: 'offer', name: offerName, email });
+          try {
+            const res = await fetch(API_URL, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ command: 'offer', name: offerName, email })
+            });
+            const text = await res.text();
+            const msg = document.createElement('div');
+            msg.textContent = res.ok ? '✅ Offer sent!' : text;
+            msg.style.color = '#33ff33';
+            msg.classList.add('flash-success');
+            terminalContent.appendChild(msg);
+          } catch (err) {
+            const errDiv = document.createElement('div');
+            errDiv.textContent = 'Error sending offer';
+            errDiv.style.color = '#ff6666';
+            terminalContent.appendChild(errDiv);
+          }
+          terminalInput.value = '';
+          scrollToBottom();
+          return;
+        }
+      }
+
+      if (cmdLower === 'offer') {
+        offerState = 'name';
+        offerName = '';
+        const prompt = document.createElement('div');
+        prompt.textContent = 'Enter your name:';
+        prompt.style.color = '#33ff33';
+        terminalContent.appendChild(prompt);
+        terminalInput.value = '';
+        scrollToBottom();
+        return;
+      }
       if (openCommands[cmdLower]) {
         window.open(openCommands[cmdLower], '_blank');
         const response = document.createElement('div');


### PR DESCRIPTION
## Summary
- handle CORS preflight in Lambda
- send `offer` data to Zapier webhook
- ensure API Gateway exposes OPTIONS route
- implement interactive `offer` command in terminal
- log Zapier payload and add success animation

## Testing
- `node -e "require('./lambda/commands.js')"`
- `terraform init -backend=false` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f45e5b8c08330b78a51f2999c5292