### PR TITLE
Fix Zapier offer webhook

### DIFF
--- a/lambda/commands.js
+++ b/lambda/commands.js
@@ -5,12 +5,7 @@ const HEADERS = {
   'Access-Control-Allow-Headers': 'Content-Type'
 };
 
-const ZAP_WEBHOOK_URL = process.env.ZAP_WEBHOOK_URL ||
-e0e6qq-codex/restore-terminal-command-system
-  'https://hooks.zapier.com/hooks/catch/23156361/2v4xduy/';
-=======
-  'https://hooks.zapier.com/hooks/catch/000000/placeholder/';
-main
+const ZAP_WEBHOOK_URL = process.env.ZAP_WEBHOOK_URL || 'https://hooks.zapier.com/hooks/catch/23156361/2v4xduy/';
 
 exports.handler = async (event) => {
   if (event?.requestContext?.http?.method === 'OPTIONS') {
@@ -19,9 +14,7 @@ exports.handler = async (event) => {
 
   let body = {};
   try {
-    body = event?.body ?
-      (typeof event.body === 'string' ? JSON.parse(event.body) : event.body)
-      : {};
+    body = event?.body ? (typeof event.body === 'string' ? JSON.parse(event.body) : event.body) : {};
   } catch (err) {
     console.error('Invalid request body', err);
     return { statusCode: 500, headers: HEADERS, body: 'Invalid request body' };
@@ -45,7 +38,7 @@ exports.handler = async (event) => {
     'projects cloud-resume': `Cloud Resume Challenge (2024):\n• Hosted on S3, delivered through CloudFront, routed via Route 53.\n• Resume views tracked using Lambda, API Gateway, and DynamoDB.\n• CI/CD set up through GitHub Actions for zero-touch deployment.`,
     'projects terraform': `Infrastructure as Code (Terraform) (2024):\n• Modular Terraform configs for all services: Lambda, IAM, S3, DNS, APIs.\n• Enabled rollback, change previews, and infrastructure drift detection.\n• Integrated into CI/CD pipeline for automated deployments.`,
     stack: `Stack:\n- Terminal UI: React + Custom Command Handler\n- Hosting: S3 + CloudFront\n- Backend: Lambda + API Gateway\n- Data: DynamoDB\n- Infra as Code: Terraform\n- CI/CD: GitHub Actions\n- DNS: Route 53`,
-    architecture: `Infrastructure Diagram:\n+---------------------+\n|       CI/CD         |\n|---------------------|\n|  GitHub Actions     |\n+----------+----------+\n           |\n           v\n+---------------------+\n|     S3 Bucket       |\n|  Static Website     |\n+----------+----------+\n           |\n           v\n+---------------------+\n|    CloudFront CDN   |\n+----+-----------+----+\n     |           |\n     v           v\n+----------+   +------------------+\n| Route 53 |   |   API Gateway    |\n+----------+   +---------+--------+\n                      |\n                      v\n                +-----------+\n                |  Lambda   |\n                +-----+-----+\n                      |\n                      v\n                +-----------+\n                | DynamoDB  |\n                +-----------+`,
+    architecture: `Infrastructure Diagram:\n+---------------------+\n|       CI/CD         |\n|---------------------|\n|  GitHub Actions     |\n+----------+----------+\n           |\n           v\n+---------------------+\n|     S3 Bucket       |\n|  Static Website     |\n+----------+----------+\n           |\n           v\n+---------------------+\n|    CloudFront CDN   |\n+----+-----------+----+\n     |           |\n     v           v\n+----------+   +------------------+\n| Route 53 |   |   API Gateway    |\n+----------+   +---------+--------+\n             |\n                      v\n                +-----------+\n                |  Lambda   |\n                +-----+-----+\n                      |\n                      v\n                +-----------+\n                | DynamoDB  |\n                +-----------+`,
     quote: '“Ship often. Think big. Stay sharp.” – J.L.',
     clear: '__CLEAR__',
     exit: 'Logging out...\nSession terminated.',
@@ -59,22 +52,17 @@ exports.handler = async (event) => {
   try {
     if (command === 'offer') {
       const { name = '', email = '' } = body;
-e0e6qq-codex/restore-terminal-command-system
       const payload = { name, email, time: new Date().toISOString() };
       console.log('Sending to Zapier:', payload);
       const res = await fetch(ZAP_WEBHOOK_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
-
-      const res = await fetch(ZAP_WEBHOOK_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, email })
- main
       });
-      if (!res.ok) throw new Error(`Webhook error: ${res.status}`);
-      return { statusCode: 200, headers: HEADERS, body: 'Offer received' };
+      if (res.status !== 200) {
+        throw new Error(`Webhook error: ${res.status}`);
+      }
+      return { statusCode: 200, headers: HEADERS, body: 'Offer sent' };
     }
 
     const output = responses[command];

--- a/website/index.html
+++ b/website/index.html
@@ -793,10 +793,7 @@
             const msg = document.createElement('div');
             msg.textContent = res.ok ? '✅ Offer sent!' : text;
             msg.style.color = '#33ff33';
- e0e6qq-codex/restore-terminal-command-system
             msg.classList.add('flash-success');
-
-main
             terminalContent.appendChild(msg);
           } catch (err) {
             const errDiv = document.createElement('div');


### PR DESCRIPTION
## Summary
- clean up lambda `offer` handler
- send offer payload to Zapier with timestamp
- remove stray debug strings from website
- keep terminal offer flow and success animation

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f4d331b5c8330913b81bd0c74c9e3