### PR TITLE
Add classic view and fix offer command

### DIFF
--- a/infra/modules/command_api/main.tf
+++ b/infra/modules/command_api/main.tf
@@ -45,6 +45,11 @@ resource "aws_lambda_function" "command" {
 resource "aws_apigatewayv2_api" "api" {
   name          = "${var.function_name}-api"
   protocol_type = "HTTP"
+  cors_configuration {
+    allow_origins = ["*"]
+    allow_methods = ["POST", "OPTIONS"]
+    allow_headers = ["content-type"]
+  }
 }
 
 resource "aws_apigatewayv2_integration" "lambda" {

--- a/lambda/commands.js
+++ b/lambda/commands.js
@@ -23,8 +23,30 @@ exports.handler = async (event) => {
   const command = (body.command || '').trim().toLowerCase();
 
   const responses = {
-    help: `Available Commands:\n--------------------\naws s3 ls           – list S3 buckets\nview counter        – fetch visitor count\nterraform apply     – apply infra (simulated)\nmotd                – welcome message\nwhoami              – user identity\nbio                 – about Joe Leto\nresume              – open resume PDF\nlinkedin            – LinkedIn profile\ngithub              – GitHub profile\nemail               – contact via email\nprojects            – list cloud projects\nstack               – show stack details\narchitecture        – show architecture diagram\nquote               – inspiration\noffer               – send your info\njoker mode          – activate Matrix rain\nclear               – clear screen\nexit                – log out\nsource code         – browse source repo`,
-    'aws s3 ls': '[bucket] josephaleto.io\n[bucket] resume-storage\n[bucket] inframirror-assets',
+    help: `Available Commands:
+--------------------
+aws s3 ls           – list S3 buckets
+view counter        – fetch visitor count
+terraform apply     – apply infra (simulated)
+motd                – welcome message
+whoami              – user identity
+bio                 – about Joe Leto
+resume              – open resume PDF
+linkedin            – LinkedIn profile
+github              – GitHub profile
+email               – contact via email
+projects            – list cloud projects
+stack               – show stack details
+architecture        – show architecture diagram
+quote               – inspiration
+offer               – send your info
+joker mode          – activate Matrix rain
+professional mode   – normal theme
+view classic        – classic scroll view
+clear               – clear screen
+exit                – log out
+source code         – browse source repo`,
+'aws s3 ls': '[bucket] josephaleto.io\n[bucket] resume-storage\n[bucket] inframirror-assets',
     'terraform apply': 'Applying changes...\n✓ No drift detected\n✓ Resources validated\n✓ Lambda up-to-date\n✓ DynamoDB consistent\n✓ CloudFront deployed\n\n✔ Terraform apply complete! Infrastructure looks good.',
     motd: `~~~ cloud initialized ~~~\n\nI'm Joe Leto — from high-stakes poker to cloud systems.\n\nThis isn’t just a portfolio. It’s a working terminal powered by real AWS infrastructure. Every command triggers live code I built and deployed myself.\n\nType "help" to explore.`,
     whoami: 'user: joe\ndomain: josephaleto.io\nlocation: Ashburn, Virginia',
@@ -42,7 +64,8 @@ exports.handler = async (event) => {
     quote: '“Ship often. Think big. Stay sharp.” – J.L.',
     clear: '__CLEAR__',
     exit: 'Logging out...\nSession terminated.',
-    'source code': 'Browse source: https://github.com/serversorcerer/cloud-resume-challenge'
+    'source code': 'Browse source: https://github.com/serversorcerer/cloud-resume-challenge',
+    'view classic': 'Opening classic view: https://josephaleto.io/classic.html'
   };
 
   if (!command) {
@@ -52,7 +75,7 @@ exports.handler = async (event) => {
   try {
     if (command === 'offer') {
       const { name = '', email = '' } = body;
-      const payload = { name, email, time: new Date().toISOString() };
+      const payload = { command: 'offer', name, email, time: new Date().toISOString() };
       console.log('Sending to Zapier:', payload);
       const res = await fetch(ZAP_WEBHOOK_URL, {
         method: 'POST',

--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,8 @@ README.md             → Full system documentation
    terraform init
    terraform apply
    ```
-3. Push changes to `main`. GitHub Actions will handle deployment.
+3. Push changes to `main`. GitHub Actions syncs the `website` folder to S3.
+4. After deploy, invalidate CloudFront: `aws cloudfront create-invalidation --distribution-id <id> --paths /*`.
 
 ---
 

--- a/website/classic.html
+++ b/website/classic.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Joe Leto | Classic View</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="css/main.css">
+</head>
+<body style="font-family:Poppins, sans-serif; padding:2rem; max-width:800px; margin:auto; color:#ddd; background:#0a0a0a;">
+  <h1 style="color:#00c3ff; text-shadow:0 0 4px #00c3ff;">Joe Leto</h1>
+  <p>From high-stakes poker to cloud systems. This is the scroll-friendly fallback of my terminal portfolio.</p>
+  <h2>About</h2>
+  <p>I learn best by building. This site runs on real AWS services provisioned with Terraform and deployed through GitHub Actions.</p>
+  <h2>Links</h2>
+  <ul>
+    <li><a href="https://josephaletoresume.s3.amazonaws.com/joseph-leto-soultions-architect.pdf" target="_blank">Resume</a></li>
+    <li><a href="https://www.linkedin.com/in/joseph-leto/" target="_blank">LinkedIn</a></li>
+    <li><a href="https://github.com/serversorcerer" target="_blank">GitHub</a></li>
+    <li><a href="mailto:joe@josephaleto.io">joe@josephaleto.io</a></li>
+  </ul>
+  <p><a href="index.html">Return to Terminal</a></p>
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -628,7 +628,8 @@
     'exit',
     'source code'
     ,'joker mode'
-    ,'professional mode'
+    ,'professional mode',
+    'view classic'
   ];
 
   const openCommands = {
@@ -636,7 +637,8 @@
     'linkedin': 'https://www.linkedin.com/in/joseph-leto/',
     'github': 'https://github.com/serversorcerer',
     'email': 'mailto:joe@josephaleto.io',
-    'source code': 'https://github.com/serversorcerer/cloud-resume-challenge'
+    'source code': 'https://github.com/serversorcerer/cloud-resume-challenge',
+    'view classic': 'classic.html'
   };
 
   async function executeCommand(cmd) {


### PR DESCRIPTION
## Summary
- wire up a classic scroll-based fallback page
- include `professional mode` and `view classic` in help output
- pass command, name and email to Zapier
- open classic view from the terminal
- expose CORS on the API Gateway
- document CloudFront invalidation step

## Testing
- `terraform` not installed, so validation was skipped


------
https://chatgpt.com/codex/tasks/task_e_683f6deae9848330b61d8de90216d3c6