### PR TITLE
Fix terminal cursor baseline

### DIFF
--- a/website/css/main.css
+++ b/website/css/main.css
@@ -2962,8 +2962,9 @@ p.clip-animation {
   animation: blink-caret 1s steps(1) infinite;
   text-shadow: 0 0 6px #00ffff, 0 0 10px #00eaff;
   display: inline-block;
-  vertical-align: middle;
-  font-size: 1.1em;
+  vertical-align: baseline;
+  font-size: 1em;
+  line-height: 1;
   margin-left: 2px;
 }
 


### PR DESCRIPTION
## Summary
- adjust cursor CSS so the block cursor lines up with typed text

## Testing
- `terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534c35c2f0833082c1b5a29b2d5d9b