### PR TITLE
fix payout logic

### DIFF
--- a/lambda/blackjack.js
+++ b/lambda/blackjack.js
@@ -1,6 +1,6 @@
 const { v4: uuidv4 } = require('uuid');
 const BlackjackGame = require('./lib/game');
-const resolveGame = require('./lib/resolution');
+const { resolveGame } = require('./lib/resolution');
 const Player = require('./lib/player');
 const {
   MIN_BET,

--- a/lambda/lib/game.js
+++ b/lambda/lib/game.js
@@ -3,6 +3,7 @@ const {
   NUM_DECKS,
   MAX_SPLITS,
 } = require('./constants');
+const { calculatePayout } = require('./resolution');
 
 const SUITS = ['♠️', '♥️', '♦️', '♣️'];
 const RANKS = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
@@ -275,25 +276,25 @@ class BlackjackGame {
     const dealerBlackjack = this.isBlackjack(dealerCards);
 
     if (playerBlackjack && !dealerBlackjack) {
-      if (!isSplitHand) return { result: 'blackjack', bet };
-      return { result: 'win', bet };
+      const result = isSplitHand ? 'win' : 'blackjack';
+      return { result, bet, payout: calculatePayout(result, bet) };
     }
 
     if (dealerBlackjack && !playerBlackjack) {
-      return { result: 'lose', bet };
+      return { result: 'lose', bet, payout: calculatePayout('lose', bet) };
     }
 
     if (playerBlackjack && dealerBlackjack) {
-      if (!isSplitHand) return { result: 'push', bet };
-      return { result: 'lose', bet };
+      if (!isSplitHand) return { result: 'push', bet, payout: calculatePayout('push', bet) };
+      return { result: 'lose', bet, payout: calculatePayout('lose', bet) };
     }
 
-    if (this.isBust(playerCards)) return { result: 'lose', bet };
-    if (this.isBust(dealerCards)) return { result: 'win', bet };
+    if (this.isBust(playerCards)) return { result: 'lose', bet, payout: calculatePayout('lose', bet) };
+    if (this.isBust(dealerCards)) return { result: 'win', bet, payout: calculatePayout('win', bet) };
 
-    if (playerValue > dealerValue) return { result: 'win', bet };
-    if (playerValue < dealerValue) return { result: 'lose', bet };
-    return { result: 'push', bet };
+    if (playerValue > dealerValue) return { result: 'win', bet, payout: calculatePayout('win', bet) };
+    if (playerValue < dealerValue) return { result: 'lose', bet, payout: calculatePayout('lose', bet) };
+    return { result: 'push', bet, payout: calculatePayout('push', bet) };
   }
 
   getGameState() {


### PR DESCRIPTION
## Summary
- add `calculatePayout` helper and export it
- use payout helper in `resolveGame`
- import payout helper in game engine and return payout with outcomes
- wire up exports and imports across modules
- log round details for debugging

## Testing
- `npm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_6866023491e0833095045b2d2ce5523b