### PR TITLE
Fix: keep agent graph and visual depth under reduced motion

### DIFF
--- a/website/css/redesign.css
+++ b/website/css/redesign.css
@@ -32,13 +32,29 @@ html { scroll-behavior: smooth; }
 }
 
 body {
-  background: var(--bg-0);
+  background:
+    radial-gradient(ellipse 90% 55% at 75% -5%, rgba(0, 94, 255, 0.13), transparent 60%),
+    radial-gradient(ellipse 70% 45% at 8% 28%, rgba(0, 195, 255, 0.06), transparent 60%),
+    var(--bg-0);
   color: var(--text);
   font-family: var(--font-body);
   font-size: 1rem;
   line-height: 1.7;
   overflow-x: hidden;
   -webkit-font-smoothing: antialiased;
+}
+
+/* Faint blueprint grid over the whole canvas — depth without motion */
+body::before {
+  content: "";
+  position: fixed; inset: 0; z-index: -2;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(0, 195, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 195, 255, 0.035) 1px, transparent 1px);
+  background-size: 56px 56px;
+  -webkit-mask-image: radial-gradient(ellipse 90% 70% at 50% 25%, black 30%, transparent 80%);
+  mask-image: radial-gradient(ellipse 90% 70% at 50% 25%, black 30%, transparent 80%);
 }
 
 .mono { font-family: var(--font-mono); }
@@ -163,8 +179,12 @@ code { color: var(--cyan-bright); background: rgba(0, 195, 255, 0.08); padding: 
 .hero-fallback {
   position: absolute; inset: 0; opacity: 0;
   background:
-    radial-gradient(ellipse 70% 55% at 65% 35%, rgba(0, 94, 255, 0.18), transparent 65%),
-    radial-gradient(ellipse 45% 40% at 30% 70%, rgba(0, 195, 255, 0.10), transparent 60%);
+    radial-gradient(ellipse 70% 55% at 65% 35%, rgba(0, 94, 255, 0.30), transparent 65%),
+    radial-gradient(ellipse 45% 40% at 30% 70%, rgba(0, 195, 255, 0.18), transparent 60%),
+    radial-gradient(circle 2px at 20% 30%, rgba(92, 225, 255, 0.8), transparent 3px),
+    radial-gradient(circle 2px at 70% 20%, rgba(92, 225, 255, 0.7), transparent 3px),
+    radial-gradient(circle 2px at 85% 60%, rgba(255, 158, 44, 0.8), transparent 3px),
+    radial-gradient(circle 2px at 40% 75%, rgba(92, 225, 255, 0.6), transparent 3px);
   transition: opacity 0.6s ease;
 }
 .hero-fallback.show { opacity: 1; }
@@ -239,6 +259,23 @@ code { color: var(--cyan-bright); background: rgba(0, 195, 255, 0.08); padding: 
 
 /* ---------- Sections (shared) ---------- */
 section { position: relative; }
+
+/* Ambient section glows — alternate sides so the scroll has rhythm */
+.console {
+  background: radial-gradient(ellipse 75% 65% at 50% 18%, rgba(0, 94, 255, 0.10), transparent 65%);
+}
+.build {
+  background: radial-gradient(ellipse 65% 55% at 12% 35%, rgba(0, 195, 255, 0.07), transparent 60%);
+}
+.experience {
+  background: radial-gradient(ellipse 65% 55% at 88% 25%, rgba(0, 94, 255, 0.09), transparent 60%);
+}
+.work {
+  background: radial-gradient(ellipse 65% 55% at 15% 30%, rgba(0, 195, 255, 0.06), transparent 60%);
+}
+.skills {
+  background: radial-gradient(ellipse 60% 50% at 85% 40%, rgba(0, 94, 255, 0.07), transparent 60%);
+}
 .section-head {
   max-width: 880px;
   padding: 0 clamp(20px, 6vw, 80px);
@@ -313,9 +350,12 @@ section { position: relative; }
 
 #terminal {
   background: #04090e;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-strong);
   border-radius: 0 0 var(--radius) var(--radius);
-  box-shadow: 0 0 40px rgba(0, 195, 255, 0.12), inset 0 0 60px rgba(0, 20, 30, 0.6);
+  box-shadow:
+    0 0 60px rgba(0, 195, 255, 0.20),
+    0 24px 80px rgba(0, 40, 70, 0.45),
+    inset 0 0 60px rgba(0, 20, 30, 0.6);
   height: 420px; overflow-y: auto;
   padding: 18px 20px;
   font-family: var(--font-mono); font-size: 0.88rem; line-height: 1.65;
@@ -369,11 +409,24 @@ section { position: relative; }
 @media (max-width: 980px) { .build-grid { grid-template-columns: 1fr; max-width: 640px; } }
 
 .build-card, .work-card, .cluster {
+  position: relative; overflow: hidden;
   background: linear-gradient(160deg, var(--bg-2), var(--bg-1));
   border: 1px solid var(--line);
   border-radius: var(--radius);
   padding: 30px 28px;
+  box-shadow: 0 10px 36px rgba(0, 10, 20, 0.55);
   transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1), border-color 0.3s ease, box-shadow 0.3s ease;
+}
+.build-card::before, .work-card::before, .cluster::before {
+  content: ""; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+  background: linear-gradient(90deg, transparent 5%, rgba(0, 195, 255, 0.65), transparent 95%);
+  opacity: 0.7;
+}
+.build-card::after, .work-card::after {
+  content: ""; position: absolute; top: -55%; right: -25%;
+  width: 70%; height: 110%;
+  background: radial-gradient(ellipse closest-side, rgba(0, 195, 255, 0.07), transparent);
+  pointer-events: none;
 }
 .build-card:hover, .work-card:hover {
   transform: translateY(-5px);
@@ -508,6 +561,8 @@ body.has-cursor .cursor-dot { opacity: 0.9; }
 [data-split] .split-word { display: inline-block; will-change: transform; }
 
 /* ---------- Reduced motion ---------- */
+/* Reduced motion: kill movement, keep the visual richness.
+   The agent graph still renders — as a static frame (see hero-graph.js). */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.001s !important;
@@ -515,8 +570,6 @@ body.has-cursor .cursor-dot { opacity: 0.9; }
     transition-duration: 0.001s !important;
   }
   .scroll-cue-line, .pulse-dot, .blinking-cursor { animation: none !important; }
-  .hero-fallback { opacity: 1; }
-  #agentGraph { display: none; }
 }
 
 /* JS-disabled / pre-JS state: everything visible by default.

--- a/website/index.html
+++ b/website/index.html
@@ -59,7 +59,7 @@
     href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap"
     rel="stylesheet">
 
-  <link rel="stylesheet" href="css/redesign.css?v=1">
+  <link rel="stylesheet" href="css/redesign.css?v=2">
 </head>
 
 <body>

--- a/website/js/redesign/hero-graph.js
+++ b/website/js/redesign/hero-graph.js
@@ -10,8 +10,9 @@ function showFallback() {
   if (fallback) fallback.classList.add('show');
 }
 
+// Under reduced motion we still draw the graph — just as a static frame.
 const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-if (!canvas || reducedMotion) {
+if (!canvas) {
   showFallback();
 } else {
   init();
@@ -74,7 +75,7 @@ function init() {
   const lineGeo = new THREE.BufferGeometry();
   lineGeo.setAttribute('position', new THREE.BufferAttribute(linePositions, 3));
   const lineMat = new THREE.LineBasicMaterial({
-    color: BLUE, transparent: true, opacity: 0.22,
+    color: BLUE, transparent: true, opacity: 0.3,
     blending: THREE.AdditiveBlending, depthWrite: false,
   });
   group.add(new THREE.LineSegments(lineGeo, lineMat));
@@ -143,9 +144,17 @@ function init() {
     renderer.setSize(w, h, false);
     camera.aspect = w / h;
     camera.updateProjectionMatrix();
+    if (reducedMotion) renderer.render(scene, camera);
   }
   resize();
   window.addEventListener('resize', resize);
+
+  // Static mode: one composed frame, no animation loop, no listeners.
+  if (reducedMotion) {
+    group.rotation.set(-0.08, 0.35, 0);
+    renderer.render(scene, camera);
+    return;
+  }
 
   // --- Render loop: paused when hero is off-screen or tab hidden ---
   let running = true;


### PR DESCRIPTION
Joe's machine (like many Windows setups) has OS animation effects disabled, so browsers report prefers-reduced-motion and the site was falling back to a flat black page. This change makes reduced motion mean 'no movement, not no design': the three.js agent graph renders as a static frame instead of hiding entirely, and new pure-CSS ambient gradients, a faint blueprint grid, card top-accent lines, and a stronger terminal glow give every section depth regardless of OS settings. Verified locally in both reduced-motion and full-motion modes.