### PR TITLE
Voice rewrite, operator section rebuild, real-only telemetry, SEO files

### DIFF
--- a/website/css/redesign.css
+++ b/website/css/redesign.css
@@ -293,36 +293,60 @@ section { position: relative; }
 .section-sub { color: var(--muted); margin-top: 18px; }
 .section-sub strong { color: var(--text); }
 
-/* ---------- ORIGIN ---------- */
-.origin { padding: 0; }
-.origin-pin {
-  min-height: 100svh;
-  display: flex; flex-direction: column; justify-content: center; align-items: center;
-  text-align: center; padding: 80px clamp(20px, 6vw, 80px);
+/* ---------- THE OPERATOR (origin) ---------- */
+.origin {
+  padding: 130px 0;
+  background: radial-gradient(ellipse 60% 55% at 80% 30%, rgba(255, 158, 44, 0.05), transparent 60%);
 }
-.origin-kicker { color: var(--signal); letter-spacing: 0.22em; font-size: 0.78rem; margin-bottom: 40px; }
-.origin-beats { position: relative; max-width: 760px; }
-.origin-beat {
-  font-family: var(--font-display);
-  font-size: clamp(1.5rem, 3.8vw, 2.6rem);
-  font-weight: 600; line-height: 1.3;
-  margin-bottom: clamp(48px, 9vh, 90px);
+.origin-inner {
+  display: grid; grid-template-columns: 1.15fr 0.85fr; gap: clamp(32px, 5vw, 72px);
+  align-items: center;
+  max-width: 1080px; margin: 0 auto;
+  padding: 0 clamp(20px, 5vw, 60px);
 }
-.origin-beat .muted {
-  display: block; font-family: var(--font-body); font-weight: 400;
-  font-size: clamp(0.95rem, 1.7vw, 1.1rem); margin-top: 14px;
-}
-.origin-beat em {
-  font-style: normal; color: var(--cyan);
-  text-shadow: 0 0 18px rgba(0, 195, 255, 0.5);
-}
+@media (max-width: 900px) { .origin-inner { grid-template-columns: 1fr; max-width: 640px; } }
 
-/* When GSAP pins the origin scene, beats stack and crossfade in place */
-.origin.motion .origin-beats { position: relative; min-height: 42vh; width: min(760px, 90vw); }
-.origin.motion .origin-beat {
-  position: absolute; left: 0; right: 0; top: 50%;
-  transform: translateY(-50%); margin: 0;
+.origin-story h2 {
+  font-size: clamp(1.9rem, 4.2vw, 3rem);
+  letter-spacing: -0.015em;
+  margin: 14px 0 26px;
 }
+.origin-story p { color: var(--muted); margin-bottom: 18px; max-width: 54ch; }
+.origin-story strong { color: var(--text); }
+
+.origin-rules {
+  position: relative; overflow: hidden;
+  background: linear-gradient(160deg, var(--bg-2), var(--bg-1));
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 28px 26px;
+  box-shadow: 0 14px 44px rgba(0, 10, 20, 0.55);
+}
+.origin-rules::before {
+  content: ""; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+  background: linear-gradient(90deg, transparent 5%, rgba(255, 158, 44, 0.7), transparent 95%);
+}
+.origin-rules::after {
+  content: "♠"; position: absolute; right: -18px; bottom: -42px;
+  font-size: 11rem; line-height: 1;
+  color: rgba(0, 195, 255, 0.05);
+  pointer-events: none;
+}
+.rules-title {
+  color: var(--signal); font-size: 0.72rem; letter-spacing: 0.2em;
+  text-transform: uppercase; margin-bottom: 18px;
+}
+.rules-list { list-style: none; }
+.rules-list li {
+  display: grid; grid-template-columns: 1fr auto 1fr; gap: 12px;
+  align-items: baseline;
+  padding: 11px 0; font-size: 0.8rem;
+  border-top: 1px dashed rgba(0, 195, 255, 0.14);
+  color: var(--muted);
+}
+.rules-list li span:last-child { color: var(--cyan-bright); text-align: right; }
+.rules-list li:last-child span:last-child { color: var(--signal); }
+.rule-arrow { color: var(--signal); }
 
 /* ---------- CONSOLE ---------- */
 .console { padding: 110px 0 90px; }
@@ -561,6 +585,7 @@ section { position: relative; }
   background: var(--ok); box-shadow: 0 0 8px var(--ok);
 }
 .tick.amber { color: var(--signal); }
+.tick-pending { display: none; }
 @keyframes tickerScroll {
   from { transform: translateX(0); }
   to { transform: translateX(-50%); }
@@ -605,25 +630,6 @@ section { position: relative; }
 @media (max-width: 640px) {
   .pipe-stage text { font-size: 24px; }
   .pipe-stage .pipe-sub { font-size: 18px; }
-}
-
-/* ---------- Stat counters ---------- */
-.stat-row {
-  display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px;
-  max-width: 1080px; margin: 0 auto 64px;
-  padding: 0 clamp(20px, 5vw, 60px);
-  text-align: center;
-}
-@media (max-width: 860px) { .stat-row { grid-template-columns: repeat(2, 1fr); } }
-.stat { display: flex; flex-direction: column; gap: 6px; }
-.stat-num {
-  font-size: clamp(2rem, 4.5vw, 3.2rem); font-weight: 700;
-  color: var(--cyan-bright);
-  text-shadow: 0 0 22px rgba(0, 195, 255, 0.45);
-}
-.stat-label {
-  font-size: 0.78rem; color: var(--muted);
-  letter-spacing: 0.05em;
 }
 
 /* ---------- Contact extras ---------- */

--- a/website/index.html
+++ b/website/index.html
@@ -59,7 +59,7 @@
     href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap"
     rel="stylesheet">
 
-  <link rel="stylesheet" href="css/redesign.css?v=3">
+  <link rel="stylesheet" href="css/redesign.css?v=4">
 </head>
 
 <body>
@@ -111,9 +111,9 @@
         </h1>
 
         <p class="hero-sub" data-anim="rise">
-          Cloud platforms, AI agents, and automation — engineered with the discipline
-          of <strong>AWS&nbsp;Professional&nbsp;Services</strong> delivery. This site is the proof:
-          the terminal below executes on live infrastructure I designed, provisioned, and run.
+          Platform engineer at <strong>AWS&nbsp;Professional&nbsp;Services</strong>.
+          I'd rather show you working code than talk about it — the terminal below
+          runs on live infrastructure I built, and this page deployed itself.
         </p>
 
         <div class="hero-ctas" data-anim="rise">
@@ -139,35 +139,41 @@
       </a>
     </section>
 
-    <!-- ============ LIVE TELEMETRY TICKER ============ -->
+    <!-- ============ LIVE TELEMETRY TICKER (real data only — items appear as they load) ============ -->
     <div class="ticker" aria-hidden="true">
       <div class="ticker-track mono" id="tickerTrack">
         <span class="tick"><span class="tick-dot"></span>SYSTEMS ONLINE</span>
         <span class="tick">region: us-east-1</span>
-        <span class="tick" id="tickVisitors">visitors: —</span>
-        <span class="tick" id="tickLatency">api latency: —</span>
-        <span class="tick" id="tickDeploy">last deploy: —</span>
-        <span class="tick">terraform: no drift</span>
-        <span class="tick">pipeline: green</span>
-        <span class="tick">agents: 4 online</span>
+        <span class="tick tick-pending" data-tick="visitors"></span>
+        <span class="tick tick-pending" data-tick="latency"></span>
+        <span class="tick tick-pending" data-tick="deploy"></span>
+        <span class="tick tick-pending" data-tick="pipeline"></span>
         <span class="tick amber">open to senior cloud / ai roles</span>
       </div>
     </div>
 
-    <!-- ============ ORIGIN ============ -->
-    <section class="origin" id="origin" aria-label="Origin story">
-      <div class="origin-pin">
-        <p class="origin-kicker mono">// origin</p>
-        <div class="origin-beats">
-          <p class="origin-beat" data-beat="1">I ran poker tables for a living.<br>
-            <span class="muted">Read the room. Keep the game moving. Never blink when it gets loud.</span>
-          </p>
-          <p class="origin-beat" data-beat="2">Now I run production.<br>
-            <span class="muted">Same nerves, different stakes — CI/CD pipelines, multi-account AWS,
-              platforms teams depend on.</span>
-          </p>
-          <p class="origin-beat" data-beat="3"><em>Calm is a skill. Uptime is the proof.</em></p>
+    <!-- ============ THE OPERATOR ============ -->
+    <section class="origin" id="origin" aria-label="The operator">
+      <div class="origin-inner">
+        <div class="origin-story">
+          <p class="kicker mono">// the operator</p>
+          <h2 data-split>Before I ran production,<br>I ran the table.</h2>
+          <p data-anim="rise">Years of dealing poker — real money, real tempers, no pause button —
+            taught me the job underneath the job: read the room, manage risk in real time,
+            and stay calm while everything moves.</p>
+          <p data-anim="rise">I do the same work now. The table is a multi-account AWS estate.
+            The chips are production traffic. The skill hasn't changed:
+            <strong>keep the game running, no matter what gets dealt.</strong></p>
         </div>
+        <aside class="origin-rules" data-anim="rise" aria-label="House rules">
+          <p class="rules-title mono">house rules · operator's edition</p>
+          <ul class="rules-list mono">
+            <li><span>read the table</span><span class="rule-arrow" aria-hidden="true">→</span><span>read the telemetry</span></li>
+            <li><span>protect the pot</span><span class="rule-arrow" aria-hidden="true">→</span><span>protect production</span></li>
+            <li><span>count every chip</span><span class="rule-arrow" aria-hidden="true">→</span><span>audit every change</span></li>
+            <li><span>never blink</span><span class="rule-arrow" aria-hidden="true">→</span><span>never blink</span></li>
+          </ul>
+        </aside>
       </div>
     </section>
 
@@ -254,59 +260,37 @@
         <h2 data-split>Three systems, one operator.</h2>
       </div>
 
-      <div class="stat-row" role="list" aria-label="Key metrics">
-        <div class="stat" role="listitem">
-          <span class="stat-num mono"><span data-count="64">0</span>+</span>
-          <span class="stat-label">AWS accounts standardized</span>
-        </div>
-        <div class="stat" role="listitem">
-          <span class="stat-num mono"><span data-count="500">0</span>+</span>
-          <span class="stat-label">firewall ranges in production</span>
-        </div>
-        <div class="stat" role="listitem">
-          <span class="stat-num mono"><span data-count="4">0</span></span>
-          <span class="stat-label">security scanners in CI/CD</span>
-        </div>
-        <div class="stat" role="listitem">
-          <span class="stat-num mono"><span data-count="20">0</span>+</span>
-          <span class="stat-label">live terminal commands</span>
-        </div>
-      </div>
-
       <div class="build-grid">
         <article class="build-card" data-anim="card">
           <h3><span class="card-index mono">01</span> Cloud Platforms</h3>
-          <p>Multi-account AWS that scales past one team's tribal knowledge — landing zones,
-            networking, guardrails, and the pipelines that keep them honest.</p>
+          <p>Multi-account AWS for organizations that can't afford surprises. Landing zones,
+            networking, guardrails — built so the right way is the default way.</p>
           <ul class="mono">
-            <li>64+ AWS accounts standardized with Terraform + StackSets</li>
-            <li>~40% faster provisioning</li>
-            <li>Network Firewall · 500+ approved ranges</li>
-            <li>Transit Gateway validated at enterprise scale</li>
+            <li>Terraform + StackSets provisioning</li>
+            <li>Network Firewall and Transit Gateway in production</li>
+            <li>Patterns architects and security both sign off on</li>
           </ul>
         </article>
 
         <article class="build-card" data-anim="card">
           <h3><span class="card-index mono">02</span> AI Agents</h3>
-          <p>Agentic systems with real hands — terminal, files, browser, memory — deployed as
-            production services, not weekend demos.</p>
+          <p>Self-hosted agents that do real work — research, operations, deployments —
+            with scoped credentials and a human on the loop.</p>
           <ul class="mono">
-            <li>Self-hosted agent gateway on a hardened VPS</li>
-            <li>Discord-driven ops: research, jobs, server changes</li>
-            <li>LLM tooling wired to live APIs with least privilege</li>
-            <li>Memory + cron: agents that learn and act on schedule</li>
+            <li>Always-on agent gateway, self-hosted</li>
+            <li>Driven from chat, accountable in logs</li>
+            <li>Least-privilege access to live APIs</li>
           </ul>
         </article>
 
         <article class="build-card" data-anim="card">
           <h3><span class="card-index mono">03</span> Automation</h3>
-          <p>If it happens twice, it gets a pipeline. Security scanning, release governance,
-            and workflow automation that removes humans from the boring path.</p>
+          <p>If it happens twice, it gets a pipeline. Security feedback on every change,
+            gates that block risk without blocking people.</p>
           <ul class="mono">
-            <li>4 security scanners wired into CI/CD</li>
-            <li>Deployment gates that block risk without blocking teams</li>
-            <li>n8n pipelines: research → publish → notify</li>
-            <li>Compliance exports leadership actually reads (JSON/SARIF/PDF)</li>
+            <li>Scanners wired into CI/CD</li>
+            <li>Deployment gates and release governance</li>
+            <li>n8n pipelines for everything else</li>
           </ul>
         </article>
       </div>
@@ -367,7 +351,7 @@
 
       <div class="work-grid">
         <article class="work-card" data-anim="card">
-          <p class="work-metric mono">20+ live commands</p>
+          <p class="work-metric mono">running on this page</p>
           <h3>Cloud Resume Terminal</h3>
           <p>This site. A production AWS stack with an interactive terminal — Lambda, API Gateway, S3,
             CloudFront, DynamoDB, all Terraform-managed, all deployed by CI/CD on merge.</p>
@@ -376,7 +360,7 @@
         </article>
 
         <article class="work-card" data-anim="card">
-          <p class="work-metric mono">64+ accounts · ~40% faster</p>
+          <p class="work-metric mono">enterprise aws</p>
           <h3>Enterprise Multi-Account Platform</h3>
           <p>Three-tier architecture across multiple VPCs with centralized Transit Gateway routing,
             repeatable Terraform/CloudFormation provisioning, and automated misconfiguration checks.</p>
@@ -385,7 +369,7 @@
         </article>
 
         <article class="work-card" data-anim="card">
-          <p class="work-metric mono">4 scanners · 4 environments</p>
+          <p class="work-metric mono">secure delivery</p>
           <h3>Security &amp; Release Governance Platform</h3>
           <p>Automated security scanning and release governance with deployment gates, RBAC, and
             audit exports — security feedback on every change, before it ships.</p>

--- a/website/js/redesign/motion.js
+++ b/website/js/redesign/motion.js
@@ -9,10 +9,9 @@
   if (telemetry && !reducedMotion) {
     const lines = [
       'region: us-east-1 · edge: cloudfront · state: nominal',
-      'pipeline: github-actions · last deploy: green',
-      'iac: terraform · drift: none detected',
-      'agents: 4 online · queue: empty',
-      'lambda: warm · dynamodb: PAY_PER_REQUEST',
+      'pipeline: github-actions · deploys on merge',
+      'iac: terraform · everything reviewable',
+      'lambda: warm · dynamodb: pay-per-request',
     ];
     let i = 0;
     setInterval(() => {
@@ -45,37 +44,49 @@
     });
   }
 
-  /* ---------- Telemetry ticker: real data + seamless loop ---------- */
+  /* ---------- Telemetry ticker: real data only, items appear as they load ---------- */
   const tickerTrack = document.getElementById('tickerTrack');
   if (tickerTrack) {
-    // Visitors + latency are filled by other modules; poll until they exist
+    // Duplicate items first so the -50% translate loops seamlessly;
+    // setTick() updates every copy by class, so late data lands in both halves.
+    if (!reducedMotion) tickerTrack.innerHTML += tickerTrack.innerHTML;
+
+    const setTick = (name, text) => {
+      document.querySelectorAll(`[data-tick="${name}"]`).forEach((el) => {
+        el.textContent = text;
+        el.classList.remove('tick-pending');
+      });
+    };
+
+    // Visitors + latency are produced by other modules; poll briefly until present
     const sync = setInterval(() => {
       const visitors = document.querySelector('.counter-number')?.textContent.trim();
       const latency = document.getElementById('apiLatency')?.textContent.trim();
-      const tv = document.getElementById('tickVisitors');
-      const tl = document.getElementById('tickLatency');
-      if (tv && visitors && visitors !== '—') tv.textContent = `visitors: ${visitors}`;
-      if (tl && latency && latency !== '—') tl.textContent = `api latency: ${latency}`;
-      if (tv?.textContent.includes(':') && !tv.textContent.includes('—')
-        && tl?.textContent.includes('ms')) clearInterval(sync);
-    }, 1500);
+      if (visitors && visitors !== '—') setTick('visitors', `visitors: ${visitors}`);
+      if (latency && latency.includes('ms')) setTick('latency', `api latency: ${latency}`);
+    }, 1200);
     setTimeout(() => clearInterval(sync), 30000);
 
-    // Last deploy straight from the GitHub API (public, unauthenticated)
+    // Last deploy + pipeline state straight from the GitHub API (public, unauthenticated)
     fetch('https://api.github.com/repos/serversorcerer/cloud-resume-challenge/commits/main')
       .then((r) => r.json())
       .then((data) => {
-        const td = document.getElementById('tickDeploy');
         const when = new Date(data?.commit?.committer?.date);
-        if (td && !isNaN(when)) {
+        if (!isNaN(when)) {
           const hrs = Math.max(0, Math.round((Date.now() - when) / 36e5));
-          td.textContent = `last deploy: ${hrs < 1 ? '<1h' : hrs < 48 ? hrs + 'h' : Math.round(hrs / 24) + 'd'} ago`;
+          setTick('deploy', `last deploy: ${hrs < 1 ? '<1h' : hrs < 48 ? hrs + 'h' : Math.round(hrs / 24) + 'd'} ago`);
         }
       })
       .catch(() => {});
 
-    // Duplicate items so the -50% translate loops seamlessly
-    if (!reducedMotion) tickerTrack.innerHTML += tickerTrack.innerHTML;
+    fetch('https://api.github.com/repos/serversorcerer/cloud-resume-challenge/actions/runs?branch=main&per_page=1')
+      .then((r) => r.json())
+      .then((data) => {
+        const run = data?.workflow_runs?.[0];
+        if (run?.conclusion === 'success') setTick('pipeline', 'pipeline: green');
+        else if (run?.status === 'in_progress') setTick('pipeline', 'pipeline: deploying');
+      })
+      .catch(() => {});
   }
 
   /* ---------- Copy email + toast ---------- */
@@ -93,12 +104,6 @@
         window.location.href = 'mailto:joe@josephaleto.io';
       }
     });
-  }
-
-  /* ---------- Stat counters (instant under reduced motion) ---------- */
-  const counters = document.querySelectorAll('.stat-num [data-count]');
-  if (reducedMotion || typeof gsap === 'undefined') {
-    counters.forEach((el) => { el.textContent = el.dataset.count; });
   }
 
   /* ---------- Pipeline final state under reduced motion ---------- */
@@ -188,28 +193,13 @@
     });
   });
 
-  /* ---------- Origin: pinned three-beat scene ---------- */
-  const origin = document.querySelector('.origin');
-  const beats = gsap.utils.toArray('.origin-beat');
-  if (origin && beats.length === 3) {
-    origin.classList.add('motion');
-    gsap.set(beats, { autoAlpha: 0, y: 30 });
-
-    gsap.timeline({
-      scrollTrigger: {
-        trigger: '.origin-pin',
-        start: 'top top',
-        end: '+=220%',
-        pin: true,
-        scrub: 0.6,
-      },
-    })
-      .to(beats[0], { autoAlpha: 1, y: 0, duration: 1 })
-      .to(beats[0], { autoAlpha: 0, y: -30, duration: 1 }, '+=1')
-      .to(beats[1], { autoAlpha: 1, y: 0, duration: 1 })
-      .to(beats[1], { autoAlpha: 0, y: -30, duration: 1 }, '+=1')
-      .to(beats[2], { autoAlpha: 1, y: 0, duration: 1 })
-      .to(beats[2], { scale: 1.04, duration: 1.2 });
+  /* ---------- Operator section: rule rows cascade in ---------- */
+  const ruleRows = gsap.utils.toArray('.rules-list li');
+  if (ruleRows.length) {
+    gsap.from(ruleRows, {
+      x: 26, autoAlpha: 0, duration: 0.55, stagger: 0.12, ease: 'power3.out',
+      scrollTrigger: { trigger: '.origin-rules', start: 'top 80%' },
+    });
   }
 
   /* ---------- Experience spine draw + items ---------- */
@@ -226,20 +216,6 @@
     gsap.from(item, {
       x: -30, autoAlpha: 0, duration: 0.7, ease: 'power3.out',
       scrollTrigger: { trigger: item, start: 'top 82%' },
-    });
-  });
-
-  /* ---------- Stat counters count up on entry ---------- */
-  counters.forEach((el) => {
-    const target = parseInt(el.dataset.count, 10);
-    const obj = { v: 0 };
-    gsap.to(obj, {
-      v: target,
-      duration: 1.6,
-      ease: 'power2.out',
-      snap: { v: 1 },
-      onUpdate: () => { el.textContent = obj.v; },
-      scrollTrigger: { trigger: el.closest('.stat-row'), start: 'top 82%' },
     });
   });
 

--- a/website/js/redesign/terminal.js
+++ b/website/js/redesign/terminal.js
@@ -66,6 +66,10 @@
     if (entry.isIntersecting) { boot(); obs.disconnect(); }
   }, { threshold: 0.35 }).observe(terminalWrapper);
 
+  // Probe immediately so the telemetry ticker has real latency without
+  // waiting for the visitor to reach the terminal.
+  probeLatency();
+
   /* ---------- Real latency probe (also feeds the footnote) ---------- */
   async function probeLatency(report = false) {
     if (!API_URL) return null;
@@ -138,12 +142,11 @@ Type "automate" for the automation story.`, C.ok),
     'automate': () => print(
 `AUTOMATION DOCTRINE
 ────────────────────────────────────────────────
-  if it happens twice          → it gets a pipeline
-  4 security scanners          → wired into CI/CD
-  deployment gates             → block risk, not teams
-  64+ AWS accounts             → standardized via Terraform
-  compliance exports           → JSON / SARIF / PDF
-  this site                    → deploys itself on git push
+  if it happens twice     → it gets a pipeline
+  security feedback       → on every change, before prod
+  deployment gates        → block risk, not people
+  compliance evidence     → generated, never assembled
+  this site               → deploys itself on git push
 
 Humans for judgment. Machines for repetition.`, C.ok),
 
@@ -169,9 +172,9 @@ Humans for judgment. Machines for repetition.`, C.ok),
 ────────────────────────────────────────────────
   role targets   senior platform · ai infrastructure
                  solutions architect · automation lead
-  superpowers    multi-account AWS · CI/CD platforms
-                 AI agents with real hands · security automation
-  receipts       64+ accounts · 4 scanners · this terminal
+  focus          multi-account AWS · CI/CD platforms
+                 AI agents with real hands
+  receipts       this terminal · the pipeline that shipped it
   availability   OPEN — direct line below
 
   → joe@josephaleto.io`, C.signal);

--- a/website/robots.txt
+++ b/website/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://josephaleto.io/sitemap.xml

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://josephaleto.io/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://josephaleto.io/blackjack.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
No slop pass. Copy rewritten in Joe's actual register (matching the terminal's motd/bio voice): plain, confident, proof-over-claims. Removed the stat-counter flex row and number-led card kickers; metrics now live only in the experience timeline where they have resume context. The empty pinned origin scene is replaced with a composed two-column operator section: the poker-to-production story told properly, beside a 'house rules: operator's edition' card (read the table -> read the telemetry / never blink -> never blink). The telemetry ticker now shows only real data: API latency probed at page load, last-deploy time and pipeline state fetched from the GitHub API, visitor count from DynamoDB - and items stay hidden until their data resolves, so no more em-dash placeholders. Adds sitemap.xml and robots.txt for search indexing. No AWS changes.