### PR TITLE
Copy: sell-focused rewrite, zero em-dashes

### DIFF
--- a/website/css/redesign.css
+++ b/website/css/redesign.css
@@ -517,7 +517,7 @@ section { position: relative; }
   color: var(--muted); font-size: 0.95rem;
   padding: 6px 0 6px 18px; position: relative;
 }
-.t-item li::before { content: "—"; position: absolute; left: 0; color: var(--cyan); }
+.t-item li::before { content: "▸"; position: absolute; left: 0; color: var(--cyan); }
 
 .cert-chips { display: flex; flex-wrap: wrap; gap: 12px; }
 .chip {
@@ -651,8 +651,12 @@ section { position: relative; }
 }
 
 /* ---------- Contact extras ---------- */
+.contact-pitch {
+  max-width: 580px; margin: -18px auto 22px;
+  color: var(--text); font-size: 1.05rem; line-height: 1.6;
+}
 .contact-roles {
-  margin-top: -16px; margin-bottom: 8px;
+  margin-top: 4px; margin-bottom: 8px;
   font-size: 0.78rem; letter-spacing: 0.16em; text-transform: uppercase;
   color: var(--muted);
 }

--- a/website/index.html
+++ b/website/index.html
@@ -4,9 +4,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Joe Leto — Cloud Platform &amp; AI Agent Engineer | AWS Professional Services</title>
+  <title>Joe Leto · Cloud Platform &amp; AI Agent Engineer | AWS Professional Services</title>
   <meta name="description"
-    content="I build systems that run themselves. Cloud platforms, AI agents, and automation — engineered at AWS Professional Services scale. The terminal on this site hits live Lambda, API Gateway, and DynamoDB.">
+    content="Joe Leto builds cloud platforms, AI agents, and automation that run themselves. Live proof on this page: the terminal hits real Lambda, API Gateway, and DynamoDB. AWS Professional Services. Open to senior roles.">
   <meta name="keywords"
     content="AWS Professional Services, platform engineering, AI agents, automation, SRE, DevOps, Terraform, CI/CD, cloud architect">
   <meta name="author" content="Joe Leto">
@@ -17,16 +17,16 @@
   <!-- Open Graph -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://josephaleto.io/">
-  <meta property="og:title" content="Joe Leto — Cloud Platform &amp; AI Agent Engineer">
+  <meta property="og:title" content="Joe Leto · Cloud Platform &amp; AI Agent Engineer">
   <meta property="og:description"
-    content="I build systems that run themselves. Cloud platforms, AI agents, automation. The terminal is live — type a command, hit real AWS.">
+    content="I build systems that run themselves. Cloud platforms, AI agents, automation. The terminal is live: type a command, hit real AWS.">
   <meta property="og:image" content="https://josephaleto.io/images/og-image.jpg">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Joe Leto — Cloud Platform &amp; AI Agent Engineer">
+  <meta name="twitter:title" content="Joe Leto · Cloud Platform &amp; AI Agent Engineer">
   <meta name="twitter:description"
     content="I build systems that run themselves. Cloud platforms, AI agents, automation. The terminal is live.">
   <meta name="twitter:image" content="https://josephaleto.io/images/og-image.jpg">
@@ -59,7 +59,7 @@
     href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap"
     rel="stylesheet">
 
-  <link rel="stylesheet" href="css/redesign.css?v=5">
+  <link rel="stylesheet" href="css/redesign.css?v=6">
 </head>
 
 <body>
@@ -67,7 +67,7 @@
 
   <!-- Fixed HUD nav -->
   <header class="hud-nav" id="hudNav">
-    <a class="brand" href="#hero" aria-label="Joe Leto — home">
+    <a class="brand" href="#hero" aria-label="Joe Leto, home">
       <span class="brand-mark" aria-hidden="true"></span>
       <span class="brand-text">JL<span class="brand-dim">·OPS</span></span>
     </a>
@@ -103,7 +103,7 @@
       <div class="hero-content">
         <p class="status-chip mono" data-anim="rise">
           <span class="pulse-dot" aria-hidden="true"></span>
-          SYSTEMS ONLINE — OPEN TO SENIOR CLOUD / AI ROLES
+          SYSTEMS ONLINE · OPEN TO SENIOR CLOUD / AI ROLES
         </p>
 
         <h1 class="hero-title" data-split>
@@ -112,8 +112,9 @@
 
         <p class="hero-sub" data-anim="rise">
           Platform engineer at <strong>AWS&nbsp;Professional&nbsp;Services</strong>.
-          I'd rather show you working code than talk about it — the terminal below
-          runs on live infrastructure I built, and this page deployed itself.
+          Most portfolios describe the work. This one runs it. The terminal below
+          executes on live infrastructure I built, and this page shipped itself.
+          Proof beats promises.
         </p>
 
         <div class="hero-ctas" data-anim="rise">
@@ -139,7 +140,7 @@
       </a>
     </section>
 
-    <!-- ============ LIVE TELEMETRY TICKER (real data only — items appear as they load) ============ -->
+    <!-- ============ LIVE TELEMETRY TICKER (real data only; items appear as they load) ============ -->
     <div class="ticker" aria-hidden="true">
       <div class="ticker-track mono" id="tickerTrack">
         <span class="tick"><span class="tick-dot"></span>SYSTEMS ONLINE</span>
@@ -158,11 +159,11 @@
         <div class="origin-story">
           <p class="kicker mono">// the operator</p>
           <h2 data-split>Before I ran production,<br>I ran the table.</h2>
-          <p data-anim="rise">Years of dealing poker — real money, real tempers, no pause button —
-            taught me the job underneath the job: read the room, manage risk in real time,
-            and stay calm while everything moves.</p>
-          <p data-anim="rise">I do the same work now. The table is a multi-account AWS estate.
-            The chips are production traffic. The skill hasn't changed:
+          <p data-anim="rise">For years I dealt poker for a living. Real money, real tempers,
+            no pause button. It taught me the job underneath the job: read the room,
+            manage risk in real time, and stay calm while everything moves at once.</p>
+          <p data-anim="rise">Today the table is a multi-account AWS estate and the chips are
+            production traffic. The skill is identical:
             <strong>keep the game running, no matter what gets dealt.</strong></p>
         </div>
         <aside class="origin-rules" data-anim="rise" aria-label="House rules">
@@ -182,9 +183,10 @@
       <div class="section-head">
         <p class="kicker mono">// live proof</p>
         <h2 data-split>The console is real.</h2>
-        <p class="section-sub">Every command executes on live <strong>Lambda + API Gateway + DynamoDB</strong>
-          in us-east-1 — infrastructure I wrote, terraformed, and shipped through CI/CD.
-          Try <code class="mono">help</code>, <code class="mono">agents</code>, or <code class="mono">status</code>.</p>
+        <p class="section-sub">Every command runs on live <strong>Lambda, API Gateway, and DynamoDB</strong>
+          in us-east-1. Infrastructure I wrote, terraformed, and shipped through CI/CD.
+          Don't take my word for it. Type <code class="mono">help</code>,
+          <code class="mono">agents</code>, or <code class="mono">status</code>.</p>
       </div>
 
       <div class="terminal-shell" id="terminalShell">
@@ -206,7 +208,7 @@
         </div>
       </div>
       <p class="console-footnote mono">backend: <span id="apiHost">api gateway → lambda → dynamodb</span> ·
-        latency <span id="apiLatency">—</span></p>
+        latency <span id="apiLatency">…</span></p>
     </section>
 
     <!-- ============ SELF-SHIPPING PIPELINE ============ -->
@@ -214,7 +216,7 @@
       <div class="section-head">
         <p class="kicker mono">// self-shipping</p>
         <h2 data-split>This site deploys itself.</h2>
-        <p class="section-sub">Push to <code class="mono">main</code> and the pipeline takes over —
+        <p class="section-sub">Push to <code class="mono">main</code> and the pipeline takes over:
           tests, S3 sync, CloudFront invalidation. No humans in the deploy path.
           The page you're reading shipped exactly this way.</p>
       </div>
@@ -264,7 +266,7 @@
         <article class="build-card" data-anim="card">
           <h3><span class="card-index mono">01</span> Cloud Platforms</h3>
           <p>Multi-account AWS for organizations that can't afford surprises. Landing zones,
-            networking, guardrails — built so the right way is the default way.</p>
+            networking, and guardrails built so the right way is the only easy way.</p>
           <ul class="mono">
             <li>Terraform + StackSets provisioning</li>
             <li>Network Firewall and Transit Gateway in production</li>
@@ -274,7 +276,7 @@
 
         <article class="build-card" data-anim="card">
           <h3><span class="card-index mono">02</span> AI Agents</h3>
-          <p>Self-hosted agents that do real work — research, operations, deployments —
+          <p>Self-hosted agents that do real work: research, operations, and deployments,
             with scoped credentials and a human on the loop.</p>
           <ul class="mono">
             <li>Always-on agent gateway, self-hosted</li>
@@ -309,33 +311,33 @@
         </svg>
 
         <article class="t-item" data-anim="t-item">
-          <p class="t-date mono">Jan 2026 — present</p>
+          <p class="t-date mono">Jan 2026 → Now</p>
           <h3>Lead Software Engineer · AWS Professional Services</h3>
           <p class="t-where muted">Chantilly, VA · client-facing delivery</p>
           <ul>
-            <li>Led delivery of a cloud platform automating security scanning and release governance across four environments</li>
-            <li>Shipped a React console consolidating findings, surfacing fixes, and re-running pipelines in one place</li>
-            <li>Wired four automated scanners into CI/CD — every change gets security feedback before production</li>
+            <li>Lead delivery of a cloud platform that automates security scanning and release governance across four environments</li>
+            <li>Shipped a React console that consolidates findings, surfaces fixes, and re-runs pipelines in one place</li>
+            <li>Wired four automated scanners into CI/CD so every change gets security feedback before it reaches production</li>
             <li>Built deployment gates that block risky releases automatically, plus Keycloak RBAC, compliance dashboards, and audit exports</li>
           </ul>
         </article>
 
         <article class="t-item" data-anim="t-item">
-          <p class="t-date mono">Jul 2025 — Jan 2026</p>
+          <p class="t-date mono">Jul 2025 → Jan 2026</p>
           <h3>Cloud Platform Engineer · COSMOS</h3>
           <p class="t-where muted">Strategic Business Systems · enterprise AWS</p>
           <ul>
-            <li>Standardized landing zones across 64+ AWS accounts with Terraform and StackSets — ~40% faster provisioning</li>
-            <li>Built production Network Firewall policies for 500+ approved ranges</li>
-            <li>Aligned architects, app teams, and security on one set of AWS patterns that scaled</li>
-            <li>Validated every Transit Gateway attachment for reliable enterprise network ops</li>
+            <li>Standardized landing zones across 64+ AWS accounts with Terraform and StackSets, cutting provisioning time by roughly 40%</li>
+            <li>Built production Network Firewall policies covering 500+ approved ranges</li>
+            <li>Aligned architects, app teams, and security on one set of AWS patterns that actually scaled</li>
+            <li>Validated every Transit Gateway attachment for reliable enterprise network operations</li>
           </ul>
         </article>
 
         <article class="t-item certs" data-anim="t-item">
           <p class="t-date mono">Certifications</p>
           <div class="cert-chips">
-            <span class="chip mono">AWS Solutions Architect — Associate · 2025</span>
+            <span class="chip mono">AWS Solutions Architect, Associate · 2025</span>
             <span class="chip mono">AWS Cloud Practitioner · 2023</span>
           </div>
         </article>
@@ -353,8 +355,8 @@
         <article class="work-card" data-anim="card">
           <p class="work-metric mono">running on this page</p>
           <h3>Cloud Resume Terminal</h3>
-          <p>This site. A production AWS stack with an interactive terminal — Lambda, API Gateway, S3,
-            CloudFront, DynamoDB, all Terraform-managed, all deployed by CI/CD on merge.</p>
+          <p>This site. A production AWS stack behind an interactive terminal: Lambda, API Gateway, S3,
+            CloudFront, and DynamoDB, all Terraform-managed and deployed by CI/CD on every merge.</p>
           <p class="work-links mono"><a href="https://github.com/serversorcerer/cloud-resume-challenge"
               target="_blank" rel="noopener">source ↗</a></p>
         </article>
@@ -372,13 +374,13 @@
           <p class="work-metric mono">secure delivery</p>
           <h3>Security &amp; Release Governance Platform</h3>
           <p>Automated security scanning and release governance with deployment gates, RBAC, and
-            audit exports — security feedback on every change, before it ships.</p>
+            audit exports. Security feedback on every change, before it ships.</p>
         </article>
 
         <article class="work-card" data-anim="card">
           <p class="work-metric mono">always-on · self-hosted</p>
           <h3>Agentic Ops Stack</h3>
-          <p>A self-hosted AI agent gateway on a hardened VPS plus n8n automation pipelines —
+          <p>A self-hosted AI agent gateway on a hardened VPS plus n8n automation pipelines.
             Discord-driven research, scheduled jobs, and server operations with memory and least-privilege tooling.</p>
         </article>
       </div>
@@ -431,9 +433,12 @@
     <section class="contact" id="contact" aria-label="Contact">
       <p class="status-chip mono center" data-anim="rise">
         <span class="pulse-dot" aria-hidden="true"></span>
-        SYSTEM STATUS: AVAILABLE — SENIOR CLOUD · AI AGENTS · AUTOMATION
+        SYSTEM STATUS: AVAILABLE · SENIOR CLOUD · AI AGENTS · AUTOMATION
       </p>
       <h2 class="contact-title" data-split>Let's build systems<br>that don't blink.</h2>
+      <p class="contact-pitch" data-anim="rise">You just watched my work run, deploy, and prove itself.
+        If your team needs infrastructure that holds under pressure, that's the whole job for me.
+        One email and we're talking.</p>
       <p class="contact-roles mono" data-anim="rise">
         senior platform engineer · ai infrastructure · solutions architect · automation lead
       </p>
@@ -456,9 +461,9 @@
   </main>
 
   <footer class="site-footer">
-    <p class="mono muted"><span class="counter-number">—</span> visitors logged in DynamoDB</p>
-    <p class="colophon">Meta-proof: this redesign was designed, built, and shipped end-to-end by an
-      <strong>AI agent</strong> under Joe's direction — infrastructure audit, code, deploy, verification.
+    <p class="mono muted"><span class="counter-number">…</span> visitors logged in DynamoDB</p>
+    <p class="colophon">Meta-proof: an <strong>AI agent</strong> designed, built, and shipped this redesign
+      end to end under Joe's direction. Infrastructure audit, code, deploy, verification.
       <a href="https://github.com/serversorcerer/cloud-resume-challenge/pull/63" target="_blank"
         rel="noopener">Read the pull request ↗</a></p>
     <p class="muted">© 2026 Joe Leto · Built on AWS, deployed by CI/CD, narrated by a live terminal.</p>
@@ -467,7 +472,7 @@
   <div class="toast mono" id="toast" role="status" aria-live="polite">joe@josephaleto.io copied ✓</div>
   <div class="cursor-dot" id="cursorDot" aria-hidden="true"></div>
 
-  <!-- Config (generated by scripts/sync-api-urls.sh — do not hand-edit) -->
+  <!-- Config (generated by scripts/sync-api-urls.sh; do not hand-edit) -->
   <script src="js/api-config.js"></script>
 
   <!-- View counter -->
@@ -478,11 +483,11 @@
         .then(data => {
           const el = document.querySelector('.counter-number');
           if (el && data.views !== undefined) el.textContent = Number(data.views).toLocaleString();
-          else if (el) el.textContent = '—';
+          else if (el) el.textContent = '…';
         })
         .catch(() => {
           const el = document.querySelector('.counter-number');
-          if (el) el.textContent = '—';
+          if (el) el.textContent = '…';
         });
     });
   </script>

--- a/website/js/redesign/motion.js
+++ b/website/js/redesign/motion.js
@@ -62,7 +62,7 @@
     const sync = setInterval(() => {
       const visitors = document.querySelector('.counter-number')?.textContent.trim();
       const latency = document.getElementById('apiLatency')?.textContent.trim();
-      if (visitors && visitors !== '—') setTick('visitors', `visitors: ${visitors}`);
+      if (visitors && visitors !== '…') setTick('visitors', `visitors: ${visitors}`);
       if (latency && latency.includes('ms')) setTick('latency', `api latency: ${latency}`);
     }, 1200);
     setTimeout(() => clearInterval(sync), 30000);

--- a/website/js/redesign/terminal.js
+++ b/website/js/redesign/terminal.js
@@ -128,13 +128,13 @@
   /* ---------- New client-side commands (agent era) ---------- */
   const localCommands = {
     'agents': () => print(
-`AGENT ROSTER — self-hosted, production-deployed
+`AGENT ROSTER · self-hosted, production-deployed
 ────────────────────────────────────────────────
   ops-gateway    self-hosted AI agent on a hardened VPS
                  discord-driven: research, jobs, server ops
   n8n-pipelines  workflow automation: research → publish → notify
   llm-tooling    least-privilege agents wired to live APIs
-  this-site      the terminal you're typing into — lambda-backed
+  this-site      the terminal you're typing into, lambda-backed
 
 Agents with real hands: terminal, files, browser, memory.
 Type "automate" for the automation story.`, C.ok),
@@ -155,27 +155,27 @@ Humans for judgment. Machines for repetition.`, C.ok),
       const result = await probeLatency(true);
       if (result && result.ok) {
         print(
-`SYSTEM STATUS — all green
+`SYSTEM STATUS · all green
   api gateway   ONLINE   (${result.ms}ms round-trip)
   lambda        WARM
   dynamodb      REACHABLE (us-east-1)
   cloudfront    SERVING THIS PAGE
   operator      AVAILABLE FOR SENIOR ROLES`, C.ok);
       } else {
-        print('api unreachable — even good systems have bad days. try again.', C.err);
+        print('api unreachable. even good systems have bad days. try again.', C.err);
       }
     },
 
     'hire': () => {
       print(
-`HIRING JOE — quick brief
+`HIRING JOE · quick brief
 ────────────────────────────────────────────────
   role targets   senior platform · ai infrastructure
                  solutions architect · automation lead
   focus          multi-account AWS · CI/CD platforms
                  AI agents with real hands
   receipts       this terminal · the pipeline that shipped it
-  availability   OPEN — direct line below
+  availability   OPEN · direct line below
 
   → joe@josephaleto.io`, C.signal);
       window.open('mailto:joe@josephaleto.io', '_blank');


### PR DESCRIPTION
## Summary
Rewrites all rendered website copy to sell harder and removes every em-dash from user-facing text.

- **Voice/selling**: tighter hero (Proof beats promises), benefit-led section subs, new persuasive contact pitch line, sharpened experience/work copy.
- **No em-dashes**: every rendered em-dash replaced (title/meta/OG/Twitter, hero status chip, operator story, console, pipeline, capabilities, experience dates + cert chip, work cards, contact status chip, footer colophon, live terminal output, screen-reader brand label).
- **Placeholders**: loading dashes (latency, visitor counter) now ellipsis; date ranges use arrows; experience bullet marker swapped off the em-dash glyph.
- CSS cache-bust v5 to v6 + small .contact-pitch style.

Remaining em-dashes exist only in source code comments (not rendered).

## Test plan
- [x] Local preview: all sections render, contact pitch lays out cleanly, latency shows real data
- [x] Grep confirms no em-dashes in rendered HTML/CSS/JS output
- [x] No linter errors

Made with [Cursor](https://cursor.com)