### PR TITLE
Copy: position title as Platform Engineer (Cloud + AI Infrastructure)

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -40,7 +40,7 @@
     "alternateName": "Joe Leto",
     "url": "https://josephaleto.io",
     "email": "mailto:joe@josephaleto.io",
-    "jobTitle": "Lead Software Engineer",
+    "jobTitle": "Platform Engineer (Cloud + AI Infrastructure)",
     "worksFor": { "@type": "Organization", "name": "AWS Professional Services" },
     "address": { "@type": "PostalAddress", "addressLocality": "Ashburn", "addressRegion": "VA", "addressCountry": "US" },
     "sameAs": [
@@ -128,7 +128,7 @@
 
         <ul class="hero-meta mono" data-anim="rise">
           <li>Ashburn, VA</li>
-          <li>Lead Software Engineer · AWS ProServe</li>
+          <li>Platform Engineer · Cloud + AI Infrastructure</li>
           <li><a href="https://josephaletoresume.s3.amazonaws.com/joseph-leto-soultions-architect.pdf"
               target="_blank" rel="noopener">Download CV ↓</a></li>
         </ul>
@@ -312,8 +312,8 @@
 
         <article class="t-item" data-anim="t-item">
           <p class="t-date mono">Jan 2026 → Now</p>
-          <h3>Lead Software Engineer · AWS Professional Services</h3>
-          <p class="t-where muted">Chantilly, VA · client-facing delivery</p>
+          <h3>Platform Engineer, Cloud + AI Infrastructure · AWS Professional Services</h3>
+          <p class="t-where muted">Chantilly, VA · official title: Software Development Engineer · client-facing delivery</p>
           <ul>
             <li>Lead delivery of a cloud platform that automates security scanning and release governance across four environments</li>
             <li>Shipped a React console that consolidates findings, surfaces fixes, and re-runs pipelines in one place</li>


### PR DESCRIPTION
Aligns the site's title across JSON-LD jobTitle, hero meta, and the experience entry to a market-strong functional title. Keeps the official title (Software Development Engineer) noted on the actual ProServe role for honesty and verifiability.