### PR TITLE
Refine: single-accent design system + cohesive card reveals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ blackjack-function.zip
 *.swo
 *~
 
+# Cursor local tooling state (skills, rules, project cache)
+.cursor/
+
 # OS generated files
 .DS_Store
 .DS_Store?

--- a/design-system/MASTER.md
+++ b/design-system/MASTER.md
@@ -1,0 +1,106 @@
+# Design System — josephaleto.io ("The Operator's Console")
+
+Global source of truth for the site redesign. Derived from the `ui-ux-pro-max`
+skill (style, color, typography, landing, ux passes) and curated against the
+project brief: away from AI-generated slop, toward a professional, sleek,
+recruiter-converting personal brand. Page-specific overrides live in
+`design-system/pages/`.
+
+Generated query:
+`senior cloud platform engineer AI infrastructure portfolio dark technical premium high-trust recruiter-facing`
+
+## Decision summary
+
+The skill's raw `--design-system` default (Liquid Glass + AI-purple `#7C3AED` +
+masonry Portfolio Grid) was rejected on purpose: it is the exact generic-AI
+aesthetic the brief forbids. The synthesized system below uses the skill's
+stronger signals instead: Dark Mode (OLED) style, the Trust & Authority +
+Conversion landing pattern, and a precision dark-cinema type system.
+
+## Pattern (landing structure)
+
+Single-page **Trust & Authority + Conversion** funnel. NOT a portfolio gallery.
+
+Order: Hero (value prop + availability + primary CTA) -> Live proof (real
+terminal + self-shipping pipeline) -> Capabilities -> Experience / Selected work
+-> Contact CTA. One unmistakable primary CTA ("Let's talk" / email) repeated at
+top, mid, and end. Verification links (GitHub, LinkedIn, CV) always one click away.
+
+## Style
+
+Refined dark, editorial-technical. Near-black canvas, generous whitespace, real
+typographic hierarchy, hairline borders. The "operator" concept is expressed
+through type and the real terminal, not sci-fi cosplay. Performance and
+accessibility are treated as part of the brand (skill rated Dark/OLED as
+Performance: Excellent, Accessibility: WCAG AAA).
+
+## Color (single confident accent)
+
+| Role | Hex | Token |
+|------|-----|-------|
+| Canvas (base) | `#04070a` | `--bg-0` |
+| Surface 1 | `#0a0f15` | `--bg-1` |
+| Surface 2 | `#0e151d` | `--bg-2` |
+| Text | `#eef3f8` | `--text` |
+| Muted text | `#9fb0bf` | `--muted` |
+| Dim text | `#6b7c8a` | `--dim` |
+| Hairline | `rgba(234,242,249,0.08)` | `--line` |
+| Hairline strong | `rgba(234,242,249,0.16)` | `--line-strong` |
+| **Accent (signature)** | `#ff9e2c` | `--accent` / `--signal` |
+| Accent soft | `#ffc279` | `--accent-soft` |
+| Accent press | `#e8861a` | `--accent-press` |
+| Live / OK only | `#43d6a0` | `--ok` |
+| Error (terminal) | `#ff6b6b` | `--err` |
+
+Rules:
+- ONE accent (amber `#ff9e2c`) for CTAs, links, kickers, active/hover, focus.
+- Green (`--ok`) is reserved strictly for genuine live/status indicators
+  (pulse dots, "LIVE" label, terminal success). Never decorative.
+- No purple, no second blue/cyan accent, no gradient "blobs", no glassmorphism
+  for its own sake. Borders are neutral hairlines, not glowing cyan.
+
+## Typography
+
+- Display / headings: **Space Grotesk** (600/700), tight tracking on large sizes
+  (`-0.03em` on hero display, `-0.02em` on H2).
+- Body: **Inter** (400/500/600), line-height ~1.65.
+- Mono / labels / telemetry / terminal: **JetBrains Mono** (400/500/700),
+  uppercase + wide tracking for kickers and labels.
+
+Scale (clamp): hero `clamp(2.7rem,7vw,5.2rem)` / H2 `clamp(2rem,4.4vw,3.1rem)` /
+H3 ~1.3rem / body 1rem / label 0.72-0.8rem.
+
+## Effects & motion (restraint)
+
+- Easing: ease-out on enter, ease-in on exit. No linear UI transitions.
+- 1-2 animated elements per viewport maximum. No animate-everything.
+- All GSAP ScrollTrigger choreography gated behind `prefers-reduced-motion`.
+- z-index scale: content 1-10, nav 100, skip-link 200, cursor 300, toast 400.
+- Lazy-load below-the-fold media; defer non-critical JS.
+- WebGL hero is cheap (capped DPR, paused off-screen) with a static fallback and
+  a static frame under reduced motion. Mesh is neutral slate, signals are amber.
+
+## Anti-patterns to avoid (from skill + brief)
+
+- AI-purple, glassmorphism for its own sake, gradient blobs.
+- Accent-color soup (the old cyan + blue + amber + green mix).
+- Sci-fi HUD clutter: corner brackets, scanlines, glitch, telemetry noise.
+- "Fast" janky animations; decorative infinite animations.
+- Fake/rounded vanity metrics. Every claim backed by something real.
+- Em-dashes in copy.
+
+## Conversion checklist
+
+- [ ] Above the fold (375px + 1366px): who, what, level, "open to work", one CTA.
+- [ ] Primary CTA repeated top / mid / end; mailto + copy-email both work.
+- [ ] Strongest proof (live terminal, self-shipping pipeline) kept high.
+- [ ] GitHub / LinkedIn / CV reachable in one click.
+
+## Accessibility / quality gates
+
+- [ ] Body text contrast >= 4.5:1; large text >= 3:1 on dark.
+- [ ] Visible focus rings (amber) on all interactive elements.
+- [ ] `prefers-reduced-motion` respected end to end.
+- [ ] Keyboard nav + skip-link + semantic landmarks intact.
+- [ ] No horizontal scroll at 375 / 768 / 1366 / large desktop.
+- [ ] SEO preserved: title, meta description, canonical, OG, Twitter, JSON-LD.

--- a/website/css/redesign.css
+++ b/website/css/redesign.css
@@ -1,84 +1,107 @@
 /* ============================================================
-   josephaleto.io — "The Operator's Console" design system
-   Palette: near-black canvas, cyan signal, amber CTA
-   Type: Space Grotesk (display) · Inter (body) · JetBrains Mono
+   josephaleto.io — "The Operator's Console"
+   Single-accent system: near-black canvas, one amber signal,
+   green reserved for live status only. Neutral hairlines, no
+   gradient blobs, no HUD cosplay. Type does the work.
+   Display: Space Grotesk · Body: Inter · Mono: JetBrains Mono
+   z-index scale: content 1-10 · nav 100 · skip 200 · cursor 300 · toast 400
    ============================================================ */
 
 :root {
-  --bg-0: #030608;
-  --bg-1: #070d14;
-  --bg-2: #0b141e;
-  --line: rgba(0, 195, 255, 0.14);
-  --line-strong: rgba(0, 195, 255, 0.35);
-  --cyan: #00c3ff;
-  --cyan-bright: #5ce1ff;
-  --blue: #005eff;
+  --bg-0: #04070a;
+  --bg-1: #0a0f15;
+  --bg-2: #0e151d;
+
+  --line: rgba(234, 242, 249, 0.08);
+  --line-strong: rgba(234, 242, 249, 0.16);
+
+  --text: #eef3f8;
+  --muted: #9fb0bf;
+  --dim: #6b7c8a;
+
+  /* Single signature accent. --signal/--cyan kept as aliases so the
+     terminal's accent easter eggs keep working without a second hue. */
+  --accent: #ff9e2c;
+  --accent-soft: #ffc279;
+  --accent-press: #e8861a;
   --signal: #ff9e2c;
-  --ok: #43ffa4;
-  --text: #eaf2f9;
-  --muted: #aabfce;
+  --cyan: #ff9e2c;
+  --cyan-bright: #ffc279;
+
+  /* Live / status only — never decorative. */
+  --ok: #43d6a0;
+
   --font-display: "Space Grotesk", system-ui, sans-serif;
   --font-body: "Inter", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, monospace;
-  --radius: 10px;
+
+  --radius: 12px;
+  --radius-sm: 8px;
   --nav-h: 64px;
+
+  --maxw: 1120px;
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
-html { scroll-behavior: smooth; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
 }
 
-/* Anchor targets clear the fixed HUD nav instead of hiding under it */
 section[id], div[id] { scroll-margin-top: calc(var(--nav-h) + 18px); }
 
-/* Branded text selection */
-::selection { background: rgba(0, 195, 255, 0.28); color: #fff; }
-::-moz-selection { background: rgba(0, 195, 255, 0.28); color: #fff; }
+::selection { background: rgba(255, 158, 44, 0.26); color: #fff; }
+::-moz-selection { background: rgba(255, 158, 44, 0.26); color: #fff; }
 
 body {
   background:
-    radial-gradient(ellipse 90% 55% at 75% -5%, rgba(0, 94, 255, 0.13), transparent 60%),
-    radial-gradient(ellipse 70% 45% at 8% 28%, rgba(0, 195, 255, 0.06), transparent 60%),
+    radial-gradient(ellipse 110% 50% at 50% -12%, rgba(255, 158, 44, 0.05), transparent 60%),
     var(--bg-0);
   color: var(--text);
   font-family: var(--font-body);
   font-size: 1rem;
-  line-height: 1.7;
+  line-height: 1.65;
   overflow-x: hidden;
   -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-/* Faint blueprint grid over the whole canvas — depth without motion */
+/* Faint neutral blueprint grid — depth without color noise. */
 body::before {
   content: "";
   position: fixed; inset: 0; z-index: -2;
   pointer-events: none;
   background-image:
-    linear-gradient(rgba(0, 195, 255, 0.035) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(0, 195, 255, 0.035) 1px, transparent 1px);
-  background-size: 56px 56px;
-  -webkit-mask-image: radial-gradient(ellipse 90% 70% at 50% 25%, black 30%, transparent 80%);
-  mask-image: radial-gradient(ellipse 90% 70% at 50% 25%, black 30%, transparent 80%);
+    linear-gradient(rgba(234, 242, 249, 0.022) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(234, 242, 249, 0.022) 1px, transparent 1px);
+  background-size: 64px 64px;
+  -webkit-mask-image: radial-gradient(ellipse 95% 70% at 50% 22%, black 25%, transparent 80%);
+  mask-image: radial-gradient(ellipse 95% 70% at 50% 22%, black 25%, transparent 80%);
 }
 
 .mono { font-family: var(--font-mono); }
 .muted { color: var(--muted); }
 .center { justify-content: center; text-align: center; }
 
-h1, h2, h3 { font-family: var(--font-display); font-weight: 600; line-height: 1.12; }
+h1, h2, h3 { font-family: var(--font-display); font-weight: 600; line-height: 1.1; }
 
-a { color: var(--cyan); text-decoration: none; }
-a:hover { color: var(--cyan-bright); }
+p { text-wrap: pretty; }
+
+a { color: var(--accent); text-decoration: none; transition: color 0.2s ease; }
+a:hover { color: var(--accent-soft); }
 a:focus-visible, button:focus-visible, input:focus-visible, .btn:focus-visible {
-  outline: 2px solid var(--signal);
+  outline: 2px solid var(--accent);
   outline-offset: 3px;
   border-radius: 4px;
 }
 
-code { color: var(--cyan-bright); background: rgba(0, 195, 255, 0.08); padding: 0.1em 0.45em; border-radius: 4px; font-size: 0.9em; }
+code {
+  color: var(--accent-soft);
+  background: rgba(255, 158, 44, 0.09);
+  padding: 0.1em 0.45em; border-radius: 4px; font-size: 0.9em;
+  font-family: var(--font-mono);
+}
 
 .sr-only {
   position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
@@ -87,7 +110,7 @@ code { color: var(--cyan-bright); background: rgba(0, 195, 255, 0.08); padding: 
 
 .skip-link {
   position: fixed; top: -48px; left: 16px; z-index: 200;
-  background: var(--signal); color: #000; padding: 10px 18px;
+  background: var(--accent); color: #000; padding: 10px 18px;
   border-radius: 6px; font-family: var(--font-mono); font-size: 0.85rem;
   transition: top 0.2s ease;
 }
@@ -98,7 +121,7 @@ code { color: var(--cyan-bright); background: rgba(0, 195, 255, 0.08); padding: 
   position: fixed; inset: 0 0 auto 0; height: var(--nav-h); z-index: 100;
   display: flex; align-items: center; gap: 28px;
   padding: 0 clamp(16px, 4vw, 48px);
-  background: rgba(3, 6, 8, 0.6);
+  background: rgba(4, 7, 10, 0.72);
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
   border-bottom: 1px solid var(--line);
@@ -109,27 +132,27 @@ code { color: var(--cyan-bright); background: rgba(0, 195, 255, 0.08); padding: 
 
 .brand { display: flex; align-items: center; gap: 10px; }
 .brand-mark {
-  width: 10px; height: 10px; border-radius: 50%;
-  background: var(--cyan);
-  box-shadow: 0 0 10px var(--cyan), 0 0 22px rgba(0, 195, 255, 0.5);
+  width: 9px; height: 9px; border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 10px rgba(255, 158, 44, 0.55);
 }
 .brand-text { font-family: var(--font-mono); font-weight: 700; letter-spacing: 0.08em; color: var(--text); }
-.brand-dim { color: var(--muted); font-weight: 400; }
+.brand-dim { color: var(--dim); font-weight: 400; }
 
 .hud-nav nav { display: flex; gap: 22px; margin-left: auto; }
 .hud-nav nav a {
   font-family: var(--font-mono); font-size: 0.8rem; letter-spacing: 0.06em;
   color: var(--muted); text-transform: uppercase;
 }
-.hud-nav nav a:hover { color: var(--cyan-bright); }
+.hud-nav nav a:hover { color: var(--accent); }
 
 .nav-cta {
   font-family: var(--font-mono); font-size: 0.8rem; letter-spacing: 0.06em;
-  color: #000; background: var(--signal);
-  padding: 8px 18px; border-radius: 999px; font-weight: 700;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  color: #000; background: var(--accent);
+  padding: 9px 18px; border-radius: 999px; font-weight: 700;
+  transition: transform 0.2s ease, background 0.2s ease;
 }
-.nav-cta:hover { color: #000; transform: translateY(-1px); box-shadow: 0 0 24px rgba(255, 158, 44, 0.45); }
+.nav-cta:hover { color: #000; background: var(--accent-soft); transform: translateY(-1px); }
 
 @media (max-width: 760px) {
   .hud-nav nav { display: none; }
@@ -140,25 +163,25 @@ code { color: var(--cyan-bright); background: rgba(0, 195, 255, 0.08); padding: 
   display: inline-flex; align-items: center; gap: 10px;
   font-family: var(--font-display); font-weight: 600; font-size: 1rem;
   padding: 14px 28px; border-radius: 999px;
-  transition: transform 0.25s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.25s ease, background 0.25s ease;
+  transition: transform 0.25s cubic-bezier(0.22, 1, 0.36, 1), background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
   will-change: transform;
 }
-.btn-lg { font-size: clamp(1rem, 2.4vw, 1.35rem); padding: 18px 36px; }
-.btn-signal { background: var(--signal); color: #000; }
-.btn-signal:hover { color: #000; box-shadow: 0 0 32px rgba(255, 158, 44, 0.5); }
+.btn-lg { font-size: clamp(1rem, 2.4vw, 1.3rem); padding: 18px 34px; }
+.btn-signal { background: var(--accent); color: #000; }
+.btn-signal:hover { color: #000; background: var(--accent-soft); }
 .btn-ghost {
-  color: var(--cyan-bright); border: 1px solid var(--line-strong);
-  background: rgba(0, 195, 255, 0.04);
+  color: var(--text); border: 1px solid var(--line-strong);
+  background: transparent;
 }
-.btn-ghost:hover { background: rgba(0, 195, 255, 0.1); box-shadow: 0 0 24px rgba(0, 195, 255, 0.25); }
+.btn-ghost:hover { border-color: var(--accent); color: var(--accent-soft); }
 
 /* ---------- Status chip / pulse ---------- */
 .status-chip {
   display: inline-flex; align-items: center; gap: 10px;
-  font-size: 0.75rem; letter-spacing: 0.14em;
-  color: var(--cyan-bright);
+  font-size: 0.72rem; letter-spacing: 0.14em;
+  color: var(--muted);
   border: 1px solid var(--line);
-  background: rgba(0, 195, 255, 0.05);
+  background: rgba(234, 242, 249, 0.02);
   padding: 8px 16px; border-radius: 999px;
 }
 .pulse-dot {
@@ -166,6 +189,7 @@ code { color: var(--cyan-bright); background: rgba(0, 195, 255, 0.08); padding: 
   background: var(--ok);
   box-shadow: 0 0 8px var(--ok);
   animation: pulse 2.2s ease-in-out infinite;
+  flex: none;
 }
 .pulse-dot.ok { background: var(--ok); }
 @keyframes pulse {
@@ -186,86 +210,66 @@ code { color: var(--cyan-bright); background: rgba(0, 195, 255, 0.08); padding: 
 .hero-fallback {
   position: absolute; inset: 0; opacity: 0;
   background:
-    radial-gradient(ellipse 70% 55% at 65% 35%, rgba(0, 94, 255, 0.30), transparent 65%),
-    radial-gradient(ellipse 45% 40% at 30% 70%, rgba(0, 195, 255, 0.18), transparent 60%),
-    radial-gradient(circle 2px at 20% 30%, rgba(92, 225, 255, 0.8), transparent 3px),
-    radial-gradient(circle 2px at 70% 20%, rgba(92, 225, 255, 0.7), transparent 3px),
-    radial-gradient(circle 2px at 85% 60%, rgba(255, 158, 44, 0.8), transparent 3px),
-    radial-gradient(circle 2px at 40% 75%, rgba(92, 225, 255, 0.6), transparent 3px);
+    radial-gradient(circle 2px at 22% 32%, rgba(159, 176, 191, 0.55), transparent 3px),
+    radial-gradient(circle 2px at 68% 22%, rgba(159, 176, 191, 0.45), transparent 3px),
+    radial-gradient(circle 3px at 84% 58%, rgba(255, 158, 44, 0.75), transparent 4px),
+    radial-gradient(circle 2px at 40% 74%, rgba(159, 176, 191, 0.4), transparent 3px);
   transition: opacity 0.6s ease;
 }
 .hero-fallback.show { opacity: 1; }
 .hero-vignette {
   position: absolute; inset: 0;
   background:
-    linear-gradient(to bottom, rgba(3, 6, 8, 0.55), transparent 30%, transparent 62%, var(--bg-0) 98%),
-    radial-gradient(ellipse 120% 90% at 50% 40%, transparent 55%, rgba(3, 6, 8, 0.8));
+    linear-gradient(to bottom, rgba(4, 7, 10, 0.5), transparent 28%, transparent 64%, var(--bg-0) 99%),
+    radial-gradient(ellipse 120% 90% at 50% 40%, transparent 52%, rgba(4, 7, 10, 0.82));
 }
 
-.hud-corners { position: absolute; inset: calc(var(--nav-h) + 14px) 18px 18px; pointer-events: none; }
-.hud-corner {
-  position: absolute; width: 26px; height: 26px;
-  border: 1px solid var(--line-strong);
-  opacity: 0.7;
-}
-.hud-corner.tl { top: 0; left: 0; border-right: 0; border-bottom: 0; }
-.hud-corner.tr { top: 0; right: 0; border-left: 0; border-bottom: 0; }
-.hud-corner.bl { bottom: 0; left: 0; border-right: 0; border-top: 0; }
-.hud-corner.br { bottom: 0; right: 0; border-left: 0; border-top: 0; }
-
-.hero-telemetry {
-  position: absolute; top: calc(var(--nav-h) + 26px); right: 34px;
-  font-size: 0.68rem; letter-spacing: 0.1em; color: var(--muted);
-  opacity: 0.9; text-shadow: 0 1px 10px rgba(3, 6, 8, 0.9);
-}
-@media (max-width: 760px) { .hero-telemetry { display: none; } }
-
-.hero-content { position: relative; max-width: 980px; }
-/* Localized scrim: guarantees text contrast over the live graph without
-   hiding it — the network still breathes around and behind the words. */
+.hero-content { position: relative; max-width: 940px; }
+/* Localized scrim so hero copy keeps contrast over the live graph
+   without hiding it. */
 .hero-content::before {
   content: "";
   position: absolute; inset: -48px -120px -48px -72px;
   z-index: -1; pointer-events: none;
-  background: radial-gradient(ellipse 78% 92% at 28% 50%,
-    rgba(3, 6, 8, 0.92), rgba(3, 6, 8, 0.62) 42%, rgba(3, 6, 8, 0) 75%);
+  background: radial-gradient(ellipse 78% 92% at 26% 50%,
+    rgba(4, 7, 10, 0.92), rgba(4, 7, 10, 0.6) 42%, rgba(4, 7, 10, 0) 75%);
 }
 
 .hero-title {
-  font-size: clamp(2.6rem, 7.2vw, 5.6rem);
-  letter-spacing: -0.02em;
-  margin: 28px 0 26px;
+  font-size: clamp(2.7rem, 7vw, 5.2rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.04;
+  margin: 26px 0 24px;
 }
 .hero-title em {
-  font-style: normal; color: var(--cyan);
-  text-shadow: 0 0 18px rgba(0, 195, 255, 0.55), 0 0 50px rgba(0, 94, 255, 0.35);
+  font-style: normal; color: var(--accent);
 }
 
 .hero-sub {
-  max-width: 620px; color: #cddbe7;
-  font-size: clamp(1.02rem, 1.6vw, 1.18rem);
-  text-shadow: 0 1px 14px rgba(3, 6, 8, 0.7);
+  max-width: 600px; color: #c8d6e2;
+  font-size: clamp(1.02rem, 1.6vw, 1.16rem);
+  line-height: 1.6;
 }
 .hero-sub strong { color: #fff; font-weight: 600; }
 
-.hero-ctas { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 38px; }
+.hero-ctas { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 36px; }
 
 .hero-meta {
-  display: flex; flex-wrap: wrap; gap: 10px 28px;
-  list-style: none; margin-top: 40px;
-  font-size: 0.8rem; letter-spacing: 0.05em; color: var(--muted);
-  text-shadow: 0 1px 10px rgba(3, 6, 8, 0.8);
+  display: flex; flex-wrap: wrap; gap: 10px 26px;
+  list-style: none; margin-top: 38px;
+  font-size: 0.78rem; letter-spacing: 0.04em; color: var(--muted);
 }
-.hero-meta a { color: var(--cyan-bright); }
+.hero-meta a { color: var(--accent-soft); }
 
 .scroll-cue {
-  position: absolute; bottom: 26px; left: 50%; transform: translateX(-50%);
+  position: absolute; bottom: 24px; left: 50%; transform: translateX(-50%);
   display: flex; flex-direction: column; align-items: center; gap: 8px;
-  font-size: 0.7rem; letter-spacing: 0.3em; text-transform: uppercase; color: var(--muted);
+  font-size: 0.68rem; letter-spacing: 0.3em; text-transform: uppercase; color: var(--dim);
 }
 .scroll-cue-line {
-  width: 1px; height: 42px;
-  background: linear-gradient(to bottom, var(--cyan), transparent);
+  width: 1px; height: 40px;
+  background: linear-gradient(to bottom, var(--accent), transparent);
   animation: cueDrop 2s ease-in-out infinite;
 }
 @keyframes cueDrop {
@@ -278,80 +282,61 @@ code { color: var(--cyan-bright); background: rgba(0, 195, 255, 0.08); padding: 
 /* ---------- Sections (shared) ---------- */
 section { position: relative; }
 
-/* Ambient section glows — alternate sides so the scroll has rhythm */
-.console {
-  background: radial-gradient(ellipse 75% 65% at 50% 18%, rgba(0, 94, 255, 0.10), transparent 65%);
-}
-.build {
-  background: radial-gradient(ellipse 65% 55% at 12% 35%, rgba(0, 195, 255, 0.07), transparent 60%);
-}
-.experience {
-  background: radial-gradient(ellipse 65% 55% at 88% 25%, rgba(0, 94, 255, 0.09), transparent 60%);
-}
-.work {
-  background: radial-gradient(ellipse 65% 55% at 15% 30%, rgba(0, 195, 255, 0.06), transparent 60%);
-}
-.skills {
-  background: radial-gradient(ellipse 60% 50% at 85% 40%, rgba(0, 94, 255, 0.07), transparent 60%);
-}
 .section-head {
-  max-width: 880px;
+  max-width: 860px;
   padding: 0 clamp(20px, 6vw, 80px);
   margin: 0 auto 56px;
   text-align: center;
 }
 .kicker {
-  color: var(--signal); font-size: 0.78rem; letter-spacing: 0.22em;
+  color: var(--accent); font-size: 0.76rem; letter-spacing: 0.22em;
   text-transform: uppercase; margin-bottom: 14px;
 }
 .section-head h2, .contact-title {
-  font-size: clamp(1.9rem, 4.6vw, 3.4rem);
-  letter-spacing: -0.015em;
+  font-size: clamp(2rem, 4.4vw, 3.1rem);
+  letter-spacing: -0.02em;
 }
 .section-sub { color: var(--muted); margin-top: 18px; }
 .section-sub strong { color: var(--text); }
 
 /* ---------- THE OPERATOR (origin) ---------- */
-.origin {
-  padding: 130px 0;
-  background: radial-gradient(ellipse 60% 55% at 80% 30%, rgba(255, 158, 44, 0.05), transparent 60%);
-}
+.origin { padding: 120px 0; }
 .origin-inner {
   display: grid; grid-template-columns: 1.15fr 0.85fr; gap: clamp(32px, 5vw, 72px);
   align-items: center;
-  max-width: 1080px; margin: 0 auto;
+  max-width: 1060px; margin: 0 auto;
   padding: 0 clamp(20px, 5vw, 60px);
 }
 @media (max-width: 900px) { .origin-inner { grid-template-columns: 1fr; max-width: 640px; } }
 
 .origin-story h2 {
   font-size: clamp(1.9rem, 4.2vw, 3rem);
-  letter-spacing: -0.015em;
-  margin: 14px 0 26px;
+  letter-spacing: -0.02em;
+  margin: 14px 0 24px;
 }
 .origin-story p { color: var(--muted); margin-bottom: 18px; max-width: 54ch; }
 .origin-story strong { color: var(--text); }
 
 .origin-rules {
   position: relative; overflow: hidden;
-  background: linear-gradient(160deg, var(--bg-2), var(--bg-1));
+  background: var(--bg-1);
   border: 1px solid var(--line);
   border-radius: var(--radius);
   padding: 28px 26px;
-  box-shadow: 0 14px 44px rgba(0, 10, 20, 0.55);
 }
 .origin-rules::before {
   content: ""; position: absolute; top: 0; left: 0; right: 0; height: 2px;
-  background: linear-gradient(90deg, transparent 5%, rgba(255, 158, 44, 0.7), transparent 95%);
+  background: linear-gradient(90deg, transparent 5%, var(--accent), transparent 95%);
+  opacity: 0.6;
 }
 .origin-rules::after {
-  content: "♠"; position: absolute; right: -18px; bottom: -42px;
-  font-size: 11rem; line-height: 1;
-  color: rgba(0, 195, 255, 0.05);
+  content: "\2660"; position: absolute; right: -14px; bottom: -40px;
+  font-size: 10rem; line-height: 1;
+  color: rgba(234, 242, 249, 0.03);
   pointer-events: none;
 }
 .rules-title {
-  color: var(--signal); font-size: 0.72rem; letter-spacing: 0.2em;
+  color: var(--accent); font-size: 0.7rem; letter-spacing: 0.2em;
   text-transform: uppercase; margin-bottom: 18px;
 }
 .rules-list { list-style: none; }
@@ -359,17 +344,18 @@ section { position: relative; }
   display: grid; grid-template-columns: 1fr auto 1fr; gap: 12px;
   align-items: baseline;
   padding: 11px 0; font-size: 0.8rem;
-  border-top: 1px dashed rgba(0, 195, 255, 0.14);
+  border-top: 1px solid var(--line);
   color: var(--muted);
 }
-.rules-list li span:last-child { color: var(--cyan-bright); text-align: right; }
-.rules-list li:last-child span:last-child { color: var(--signal); }
-.rule-arrow { color: var(--signal); }
+.rules-list li:first-child { border-top: 0; }
+.rules-list li span:last-child { color: var(--text); text-align: right; }
+.rules-list li:last-child span:last-child { color: var(--accent-soft); }
+.rule-arrow { color: var(--accent); }
 
 /* ---------- CONSOLE ---------- */
 .console { padding: 110px 0 90px; }
 .terminal-shell {
-  max-width: 960px; margin: 0 auto;
+  max-width: 940px; margin: 0 auto;
   padding: 0 clamp(14px, 4vw, 40px);
 }
 .terminal-chrome {
@@ -391,20 +377,17 @@ section { position: relative; }
 }
 
 #terminal {
-  background: #04090e;
+  background: #05080c;
   border: 1px solid var(--line-strong);
   border-radius: 0 0 var(--radius) var(--radius);
-  box-shadow:
-    0 0 60px rgba(0, 195, 255, 0.20),
-    0 24px 80px rgba(0, 40, 70, 0.45),
-    inset 0 0 60px rgba(0, 20, 30, 0.6);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.5);
   height: 420px; overflow-y: auto;
   padding: 18px 20px;
   font-family: var(--font-mono); font-size: 0.88rem; line-height: 1.65;
 }
 #terminal::-webkit-scrollbar { width: 8px; }
 #terminal::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, var(--cyan), var(--blue));
+  background: rgba(255, 158, 44, 0.5);
   border-radius: 6px;
 }
 #terminal::-webkit-scrollbar-track { background: var(--bg-0); }
@@ -414,17 +397,17 @@ section { position: relative; }
   white-space: pre-wrap; overflow-x: auto;
   color: var(--ok); font-family: inherit; font-size: inherit;
 }
-#terminal-content a { color: var(--cyan-bright); text-shadow: 0 0 8px rgba(0, 195, 255, 0.6); }
+#terminal-content a { color: var(--accent-soft); }
 #terminal-content img { max-width: 100%; border-radius: 6px; margin-top: 8px; }
 
 .terminal-suggestion {
-  color: rgba(147, 167, 184, 0.55); font-size: 0.82rem; padding: 2px 0;
+  color: rgba(159, 176, 191, 0.5); font-size: 0.82rem; padding: 2px 0;
 }
 
 .terminal-input-row { position: relative; display: flex; align-items: baseline; gap: 8px; }
 #terminal-prompt { color: var(--ok); white-space: nowrap; }
-#typedText { color: #d8f4ff; }
-.blinking-cursor { color: var(--cyan); animation: blink 1.05s step-end infinite; }
+#typedText { color: #dbe8f2; }
+.blinking-cursor { color: var(--accent); animation: blink 1.05s step-end infinite; }
 @keyframes blink { 50% { opacity: 0; } }
 #terminal-input {
   position: absolute; inset: 0; width: 100%; height: 100%;
@@ -435,62 +418,55 @@ section { position: relative; }
 .terminal-fade { transition: opacity 0.45s ease; opacity: 0; }
 
 .console-footnote {
-  max-width: 960px; margin: 14px auto 0;
+  max-width: 940px; margin: 14px auto 0;
   padding: 0 clamp(14px, 4vw, 40px);
-  font-size: 0.72rem; letter-spacing: 0.06em; color: var(--muted);
+  font-size: 0.72rem; letter-spacing: 0.06em; color: var(--dim);
 }
 #apiLatency { color: var(--ok); }
 
 /* ---------- BUILD ---------- */
 .build { padding: 110px 0; }
 .build-grid {
-  display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px;
-  max-width: 1180px; margin: 0 auto;
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px;
+  max-width: var(--maxw); margin: 0 auto;
   padding: 0 clamp(20px, 5vw, 60px);
 }
-@media (max-width: 980px) { .build-grid { grid-template-columns: 1fr; max-width: 640px; } }
+@media (max-width: 980px) { .build-grid { grid-template-columns: 1fr; max-width: 600px; } }
 
 .build-card, .work-card, .cluster {
   position: relative; overflow: hidden;
-  background: linear-gradient(160deg, var(--bg-2), var(--bg-1));
+  background: var(--bg-1);
   border: 1px solid var(--line);
   border-radius: var(--radius);
   padding: 30px 28px;
-  box-shadow: 0 10px 36px rgba(0, 10, 20, 0.55);
-  transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1), border-color 0.3s ease, box-shadow 0.3s ease;
+  transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1), border-color 0.3s ease;
 }
-.build-card::before, .work-card::before, .cluster::before {
+.build-card::before, .work-card::before {
   content: ""; position: absolute; top: 0; left: 0; right: 0; height: 2px;
-  background: linear-gradient(90deg, transparent 5%, rgba(0, 195, 255, 0.65), transparent 95%);
-  opacity: 0.7;
-}
-.build-card::after, .work-card::after {
-  content: ""; position: absolute; top: -55%; right: -25%;
-  width: 70%; height: 110%;
-  background: radial-gradient(ellipse closest-side, rgba(0, 195, 255, 0.07), transparent);
-  pointer-events: none;
+  background: linear-gradient(90deg, transparent 5%, var(--accent), transparent 95%);
+  opacity: 0; transition: opacity 0.3s ease;
 }
 .build-card:hover, .work-card:hover {
-  transform: translateY(-5px);
+  transform: translateY(-4px);
   border-color: var(--line-strong);
-  box-shadow: 0 14px 44px rgba(0, 30, 50, 0.5), 0 0 26px rgba(0, 195, 255, 0.1);
 }
+.build-card:hover::before, .work-card:hover::before { opacity: 0.7; }
 
-.build-card h3 { font-size: 1.25rem; margin-bottom: 14px; display: flex; align-items: baseline; gap: 12px; }
-.card-index { color: var(--signal); font-size: 0.8rem; }
-.build-card p { color: var(--muted); font-size: 0.95rem; margin-bottom: 18px; }
+.build-card h3 { font-size: 1.22rem; margin-bottom: 14px; display: flex; align-items: baseline; gap: 12px; }
+.card-index { color: var(--accent); font-size: 0.8rem; }
+.build-card p { color: var(--muted); font-size: 0.94rem; margin-bottom: 18px; }
 .build-card ul { list-style: none; }
 .build-card li {
-  font-size: 0.78rem; color: var(--cyan-bright);
+  font-size: 0.78rem; color: var(--text);
   padding: 7px 0 7px 18px; position: relative;
-  border-top: 1px dashed rgba(0, 195, 255, 0.12);
+  border-top: 1px solid var(--line);
 }
-.build-card li::before { content: "▸"; position: absolute; left: 0; color: var(--signal); }
+.build-card li::before { content: "\25B8"; position: absolute; left: 0; color: var(--accent); }
 
 /* ---------- EXPERIENCE ---------- */
 .experience { padding: 110px 0; }
 .timeline {
-  position: relative; max-width: 860px; margin: 0 auto;
+  position: relative; max-width: 840px; margin: 0 auto;
   padding: 10px clamp(20px, 5vw, 60px) 10px calc(clamp(20px, 5vw, 60px) + 34px);
 }
 .timeline-spine {
@@ -498,77 +474,75 @@ section { position: relative; }
   width: 2px; height: 100%;
 }
 .timeline-spine line {
-  stroke: var(--cyan); stroke-width: 2;
-  filter: drop-shadow(0 0 6px rgba(0, 195, 255, 0.7));
+  stroke: var(--accent); stroke-width: 2; opacity: 0.6;
 }
 
-.t-item { position: relative; margin-bottom: 64px; }
+.t-item { position: relative; margin-bottom: 60px; }
 .t-item::before {
   content: ""; position: absolute; left: -41px; top: 6px;
   width: 12px; height: 12px; border-radius: 50%;
-  background: var(--bg-0); border: 2px solid var(--cyan);
-  box-shadow: 0 0 12px rgba(0, 195, 255, 0.8);
+  background: var(--bg-0); border: 2px solid var(--accent);
 }
-.t-date { color: var(--signal); font-size: 0.75rem; letter-spacing: 0.14em; margin-bottom: 8px; }
-.t-item h3 { font-size: 1.3rem; margin-bottom: 4px; }
+.t-date { color: var(--accent); font-size: 0.74rem; letter-spacing: 0.14em; margin-bottom: 8px; }
+.t-item h3 { font-size: 1.28rem; margin-bottom: 4px; }
 .t-where { font-size: 0.85rem; margin-bottom: 14px; }
 .t-item ul { list-style: none; }
 .t-item li {
-  color: var(--muted); font-size: 0.95rem;
+  color: var(--muted); font-size: 0.94rem;
   padding: 6px 0 6px 18px; position: relative;
 }
-.t-item li::before { content: "▸"; position: absolute; left: 0; color: var(--cyan); }
+.t-item li::before { content: "\25B8"; position: absolute; left: 0; color: var(--accent); }
 
 .cert-chips { display: flex; flex-wrap: wrap; gap: 12px; }
 .chip {
   display: inline-block;
   border: 1px solid var(--line); border-radius: 999px;
-  background: rgba(0, 195, 255, 0.05);
-  color: var(--cyan-bright);
+  background: rgba(234, 242, 249, 0.02);
+  color: var(--text);
   font-size: 0.78rem; padding: 7px 16px;
+  transition: border-color 0.2s ease, color 0.2s ease;
 }
 
 /* ---------- WORK ---------- */
 .work { padding: 110px 0; }
 .work-grid {
-  display: grid; grid-template-columns: 1fr 1fr; gap: 22px;
-  max-width: 1080px; margin: 0 auto;
+  display: grid; grid-template-columns: 1fr 1fr; gap: 20px;
+  max-width: 1060px; margin: 0 auto;
   padding: 0 clamp(20px, 5vw, 60px);
 }
-@media (max-width: 860px) { .work-grid { grid-template-columns: 1fr; max-width: 640px; } }
+@media (max-width: 860px) { .work-grid { grid-template-columns: 1fr; max-width: 600px; } }
 
-.work-metric { color: var(--signal); font-size: 0.75rem; letter-spacing: 0.16em; text-transform: uppercase; margin-bottom: 12px; }
-.work-card h3 { font-size: 1.35rem; margin-bottom: 12px; }
-.work-card p { color: var(--muted); font-size: 0.95rem; }
+.work-metric { color: var(--accent); font-size: 0.74rem; letter-spacing: 0.16em; text-transform: uppercase; margin-bottom: 12px; }
+.work-card h3 { font-size: 1.3rem; margin-bottom: 12px; }
+.work-card p { color: var(--muted); font-size: 0.94rem; }
 .work-links { margin-top: 16px; font-size: 0.8rem; }
 
 /* ---------- SKILLS ---------- */
 .skills { padding: 110px 0; }
 .skill-clusters {
-  display: grid; grid-template-columns: 1fr 1fr; gap: 22px;
-  max-width: 1080px; margin: 0 auto;
+  display: grid; grid-template-columns: 1fr 1fr; gap: 20px;
+  max-width: 1060px; margin: 0 auto;
   padding: 0 clamp(20px, 5vw, 60px);
 }
-@media (max-width: 860px) { .skill-clusters { grid-template-columns: 1fr; max-width: 640px; } }
+@media (max-width: 860px) { .skill-clusters { grid-template-columns: 1fr; max-width: 600px; } }
 .cluster h3 {
-  color: var(--signal); font-size: 0.8rem; letter-spacing: 0.2em;
+  color: var(--accent); font-size: 0.78rem; letter-spacing: 0.2em;
   text-transform: uppercase; margin-bottom: 18px; font-weight: 500;
 }
 .chips { display: flex; flex-wrap: wrap; gap: 10px; }
 .chips .chip { font-family: var(--font-body); color: var(--text); }
-.chips .chip:hover { border-color: var(--line-strong); color: var(--cyan-bright); }
+.chips .chip:hover { border-color: var(--accent); color: var(--accent-soft); }
 
 /* ---------- CONTACT ---------- */
 .contact {
   padding: 140px clamp(20px, 6vw, 80px) 120px;
   text-align: center;
-  background:
-    radial-gradient(ellipse 60% 50% at 50% 60%, rgba(0, 94, 255, 0.12), transparent 70%);
+  background: radial-gradient(ellipse 60% 50% at 50% 55%, rgba(255, 158, 44, 0.06), transparent 70%);
 }
-.contact-title { margin: 30px 0 40px; }
+.contact-title { margin: 28px 0 36px; }
 .contact-links {
   display: flex; flex-wrap: wrap; justify-content: center; gap: 14px 34px;
-  list-style: none; margin-top: 46px;
+  list-style: none; margin-top: 44px;
   font-size: 0.85rem;
 }
 
@@ -579,14 +553,14 @@ section { position: relative; }
   text-align: center; font-size: 0.82rem;
 }
 .site-footer p { margin: 4px 0; }
-.counter-number { color: var(--cyan-bright); }
+.counter-number { color: var(--accent-soft); }
 
 /* ---------- Live telemetry ticker ---------- */
 .ticker {
   overflow: hidden;
   border-top: 1px solid var(--line);
   border-bottom: 1px solid var(--line);
-  background: rgba(7, 13, 20, 0.7);
+  background: rgba(10, 15, 21, 0.7);
   padding: 12px 0;
 }
 .ticker-track {
@@ -602,7 +576,7 @@ section { position: relative; }
   width: 7px; height: 7px; border-radius: 50%;
   background: var(--ok); box-shadow: 0 0 8px var(--ok);
 }
-.tick.amber { color: var(--signal); }
+.tick.amber { color: var(--accent); }
 .tick-pending { display: none; }
 @keyframes tickerScroll {
   from { transform: translateX(0); }
@@ -616,21 +590,20 @@ section { position: relative; }
 /* ---------- Self-shipping pipeline ---------- */
 .pipeline { padding: 110px 0 90px; }
 .pipe-wrap {
-  max-width: 1080px; margin: 0 auto;
+  max-width: 1060px; margin: 0 auto;
   padding: 0 clamp(16px, 4vw, 50px);
 }
 .pipe-svg { width: 100%; height: auto; overflow: visible; }
 .pipe-base {
-  stroke: rgba(0, 195, 255, 0.18); stroke-width: 2; fill: none;
+  stroke: var(--line-strong); stroke-width: 2; fill: none;
 }
 .pipe-pulse {
-  stroke: var(--cyan); stroke-width: 2.5; fill: none;
-  filter: drop-shadow(0 0 6px rgba(0, 195, 255, 0.8));
+  stroke: var(--accent); stroke-width: 2.5; fill: none;
   stroke-dasharray: 860; stroke-dashoffset: 860;
 }
 .pipe-stage circle {
-  fill: var(--bg-1); stroke: rgba(0, 195, 255, 0.35); stroke-width: 2;
-  transition: fill 0.3s ease, stroke 0.3s ease, filter 0.3s ease;
+  fill: var(--bg-1); stroke: var(--line-strong); stroke-width: 2;
+  transition: fill 0.3s ease, stroke 0.3s ease;
 }
 .pipe-stage text {
   fill: var(--text); font-family: var(--font-mono); font-size: 17px;
@@ -638,12 +611,10 @@ section { position: relative; }
 }
 .pipe-stage .pipe-sub { fill: var(--muted); font-size: 13px; }
 .pipe-stage.lit circle {
-  fill: rgba(0, 195, 255, 0.25); stroke: var(--cyan);
-  filter: drop-shadow(0 0 10px rgba(0, 195, 255, 0.9));
+  fill: rgba(255, 158, 44, 0.18); stroke: var(--accent);
 }
 .pipe-stage:last-child.lit circle {
-  fill: rgba(255, 158, 44, 0.3); stroke: var(--signal);
-  filter: drop-shadow(0 0 12px rgba(255, 158, 44, 0.9));
+  fill: rgba(67, 214, 160, 0.2); stroke: var(--ok);
 }
 @media (max-width: 640px) {
   .pipe-stage text { font-size: 24px; }
@@ -652,12 +623,12 @@ section { position: relative; }
 
 /* ---------- Contact extras ---------- */
 .contact-pitch {
-  max-width: 580px; margin: -18px auto 22px;
-  color: var(--text); font-size: 1.05rem; line-height: 1.6;
+  max-width: 580px; margin: -14px auto 22px;
+  color: var(--text); font-size: 1.04rem; line-height: 1.6;
 }
 .contact-roles {
   margin-top: 4px; margin-bottom: 8px;
-  font-size: 0.78rem; letter-spacing: 0.16em; text-transform: uppercase;
+  font-size: 0.76rem; letter-spacing: 0.16em; text-transform: uppercase;
   color: var(--muted);
 }
 .copy-email { cursor: pointer; font-size: 0.85rem; }
@@ -669,7 +640,7 @@ section { position: relative; }
   border: 1px solid var(--line-strong);
   border-radius: 999px; padding: 10px 22px;
   font-size: 0.8rem; letter-spacing: 0.08em;
-  box-shadow: 0 8px 32px rgba(0, 20, 40, 0.7), 0 0 18px rgba(0, 195, 255, 0.2);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
   opacity: 0; pointer-events: none;
   transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.35s ease;
 }
@@ -680,7 +651,7 @@ section { position: relative; }
   max-width: 640px; margin: 10px auto !important;
   color: var(--muted); font-size: 0.82rem;
 }
-.colophon strong { color: var(--cyan-bright); font-weight: 600; }
+.colophon strong { color: var(--accent-soft); font-weight: 600; }
 
 /* ---------- Hero agent-node labels ---------- */
 .hero-labels { position: absolute; inset: 0; pointer-events: none; overflow: hidden; }
@@ -688,27 +659,25 @@ section { position: relative; }
   position: absolute; top: 0; left: 0;
   font-family: var(--font-mono); font-size: 0.62rem;
   letter-spacing: 0.12em; text-transform: uppercase;
-  color: var(--signal);
-  text-shadow: 0 0 10px rgba(255, 158, 44, 0.6);
+  color: var(--accent);
   white-space: nowrap;
   transform: translate(-50%, -180%);
-  opacity: 0.85;
+  opacity: 0.8;
 }
 
 /* ---------- Custom cursor ---------- */
 .cursor-dot {
   position: fixed; top: 0; left: 0; z-index: 300;
-  width: 10px; height: 10px; border-radius: 50%;
-  background: var(--cyan);
-  box-shadow: 0 0 12px rgba(0, 195, 255, 0.9);
+  width: 9px; height: 9px; border-radius: 50%;
+  background: var(--accent);
   pointer-events: none;
   transform: translate(-50%, -50%);
   opacity: 0;
   transition: width 0.2s ease, height 0.2s ease, opacity 0.3s ease, background 0.2s ease;
   mix-blend-mode: screen;
 }
-body.has-cursor .cursor-dot { opacity: 0.9; }
-.cursor-dot.on-link { width: 34px; height: 34px; background: rgba(0, 195, 255, 0.25); }
+body.has-cursor .cursor-dot { opacity: 0.8; }
+.cursor-dot.on-link { width: 30px; height: 30px; background: rgba(255, 158, 44, 0.22); }
 
 @media (hover: none), (pointer: coarse) { .cursor-dot { display: none; } }
 
@@ -717,8 +686,6 @@ body.has-cursor .cursor-dot { opacity: 0.9; }
 [data-split] .split-word { display: inline-block; will-change: transform; }
 
 /* ---------- Reduced motion ---------- */
-/* Reduced motion: kill movement, keep the visual richness.
-   The agent graph still renders — as a static frame (see hero-graph.js). */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.001s !important;
@@ -729,4 +696,4 @@ body.has-cursor .cursor-dot { opacity: 0.9; }
 }
 
 /* JS-disabled / pre-JS state: everything visible by default.
-   Motion script adds .motion-ready and handles initial states itself. */
+   Motion script adds choreography and handles initial states itself. */

--- a/website/favicon.svg
+++ b/website/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Joe Leto">
+  <rect width="32" height="32" rx="7" fill="#04070a"/>
+  <circle cx="16" cy="16" r="6" fill="#ff9e2c"/>
+  <circle cx="16" cy="16" r="10.5" fill="none" stroke="#ff9e2c" stroke-opacity="0.35" stroke-width="1.5"/>
+</svg>

--- a/website/index.html
+++ b/website/index.html
@@ -12,7 +12,8 @@
   <meta name="author" content="Joe Leto">
   <meta name="theme-color" content="#030608">
   <link rel="canonical" href="https://josephaleto.io/">
-  <link href="favicon.ico" rel="shortcut icon" type="image/x-icon">
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <link rel="alternate icon" href="favicon.svg">
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
@@ -59,7 +60,7 @@
     href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap"
     rel="stylesheet">
 
-  <link rel="stylesheet" href="css/redesign.css?v=6">
+  <link rel="stylesheet" href="css/redesign.css?v=7">
 </head>
 
 <body>
@@ -67,7 +68,7 @@
 
   <!-- Fixed HUD nav -->
   <header class="hud-nav" id="hudNav">
-    <a class="brand" href="#hero" aria-label="Joe Leto, home">
+    <a class="brand" href="#hero" aria-label="JL·OPS, Joe Leto home">
       <span class="brand-mark" aria-hidden="true"></span>
       <span class="brand-text">JL<span class="brand-dim">·OPS</span></span>
     </a>
@@ -91,15 +92,6 @@
         <div class="hero-vignette"></div>
       </div>
 
-      <div class="hud-corners" aria-hidden="true">
-        <span class="hud-corner tl"></span><span class="hud-corner tr"></span>
-        <span class="hud-corner bl"></span><span class="hud-corner br"></span>
-      </div>
-
-      <div class="hero-telemetry mono" aria-hidden="true">
-        <span id="telemetryLine">region: us-east-1 · edge: cloudfront · state: nominal</span>
-      </div>
-
       <div class="hero-content">
         <p class="status-chip mono" data-anim="rise">
           <span class="pulse-dot" aria-hidden="true"></span>
@@ -112,9 +104,8 @@
 
         <p class="hero-sub" data-anim="rise">
           Platform engineer at <strong>AWS&nbsp;Professional&nbsp;Services</strong>.
-          Most portfolios describe the work. This one runs it. The terminal below
-          executes on live infrastructure I built, and this page shipped itself.
-          Proof beats promises.
+          I build cloud platforms, AI agents, and automation that run without me.
+          The terminal below is live. This page shipped itself.
         </p>
 
         <div class="hero-ctas" data-anim="rise">
@@ -312,8 +303,8 @@
 
         <article class="t-item" data-anim="t-item">
           <p class="t-date mono">Jan 2026 → Now</p>
-          <h3>Platform Engineer, Cloud + AI Infrastructure · AWS Professional Services</h3>
-          <p class="t-where muted">Chantilly, VA · official title: Software Development Engineer · client-facing delivery</p>
+          <h3>Software Development Engineer · AWS Professional Services</h3>
+          <p class="t-where muted">Chantilly, VA · platform engineering: cloud + AI infrastructure · client-facing delivery</p>
           <ul>
             <li>Lead delivery of a cloud platform that automates security scanning and release governance across four environments</li>
             <li>Shipped a React console that consolidates findings, surfaces fixes, and re-runs pipelines in one place</li>
@@ -462,10 +453,10 @@
 
   <footer class="site-footer">
     <p class="mono muted"><span class="counter-number">…</span> visitors logged in DynamoDB</p>
-    <p class="colophon">Meta-proof: an <strong>AI agent</strong> designed, built, and shipped this redesign
-      end to end under Joe's direction. Infrastructure audit, code, deploy, verification.
+    <p class="colophon">I directed an <strong>AI agent</strong> to design, build, and ship this entire site.
+      Every step is in the
       <a href="https://github.com/serversorcerer/cloud-resume-challenge/pull/63" target="_blank"
-        rel="noopener">Read the pull request ↗</a></p>
+        rel="noopener">pull request ↗</a></p>
     <p class="muted">© 2026 Joe Leto · Built on AWS, deployed by CI/CD, narrated by a live terminal.</p>
   </footer>
 
@@ -500,7 +491,7 @@
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/ScrollTrigger.min.js" defer></script>
 
   <script src="js/redesign/terminal.js" defer></script>
-  <script src="js/redesign/motion.js" defer></script>
+  <script src="js/redesign/motion.js?v=2" defer></script>
   <script type="module" src="js/redesign/hero-graph.js"></script>
 </body>
 

--- a/website/js/redesign/hero-graph.js
+++ b/website/js/redesign/hero-graph.js
@@ -34,8 +34,8 @@ function init() {
   const camera = new THREE.PerspectiveCamera(55, 1, 0.1, 100);
   camera.position.set(0, 0, 16);
 
-  const CYAN = new THREE.Color('#00c3ff');
-  const BLUE = new THREE.Color('#005eff');
+  // Single-accent palette: a cool neutral mesh carrying warm amber signals.
+  const MESH = new THREE.Color('#33485a');
   const AMBER = new THREE.Color('#ff9e2c');
 
   // --- Node cloud: flattened ellipsoid, denser toward center ---
@@ -75,7 +75,7 @@ function init() {
   const lineGeo = new THREE.BufferGeometry();
   lineGeo.setAttribute('position', new THREE.BufferAttribute(linePositions, 3));
   const lineMat = new THREE.LineBasicMaterial({
-    color: BLUE, transparent: true, opacity: 0.3,
+    color: MESH, transparent: true, opacity: 0.32,
     blending: THREE.AdditiveBlending, depthWrite: false,
   });
   group.add(new THREE.LineSegments(lineGeo, lineMat));
@@ -97,7 +97,7 @@ function init() {
   // Nodes
   const nodeGeo = new THREE.BufferGeometry().setFromPoints(positions);
   const nodeMat = new THREE.PointsMaterial({
-    size: 0.55, map: dotTexture('#5ce1ff'), transparent: true, opacity: 0.9,
+    size: 0.55, map: dotTexture('#7d93a6'), transparent: true, opacity: 0.85,
     blending: THREE.AdditiveBlending, depthWrite: false, sizeAttenuation: true,
   });
   group.add(new THREE.Points(nodeGeo, nodeMat));
@@ -143,7 +143,7 @@ function init() {
   const reachGeo = new THREE.BufferGeometry();
   reachGeo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(REACH_COUNT * 6), 3));
   const reachMat = new THREE.LineBasicMaterial({
-    color: CYAN, transparent: true, opacity: 0.4,
+    color: AMBER, transparent: true, opacity: 0.4,
     blending: THREE.AdditiveBlending, depthWrite: false,
   });
   const reachLines = new THREE.LineSegments(reachGeo, reachMat);
@@ -162,7 +162,7 @@ function init() {
   const pulseGeo = new THREE.BufferGeometry();
   pulseGeo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(PULSE_COUNT * 3), 3));
   const pulseMat = new THREE.PointsMaterial({
-    size: 0.8, map: dotTexture('#00c3ff'), transparent: true, opacity: 1,
+    size: 0.8, map: dotTexture('#ff9e2c'), transparent: true, opacity: 1,
     blending: THREE.AdditiveBlending, depthWrite: false,
   });
   const pulsePoints = new THREE.Points(pulseGeo, pulseMat);
@@ -179,8 +179,12 @@ function init() {
   // --- Interaction state ---
   const pointer = { x: 0, y: 0 };
   window.addEventListener('pointermove', (e) => {
-    pointer.x = (e.clientX / window.innerWidth) * 2 - 1;
-    pointer.y = (e.clientY / window.innerHeight) * 2 - 1;
+    // Map against the canvas rect (not window) so the reach lines converge
+    // exactly under the cursor. window.innerWidth includes the scrollbar,
+    // which would shift the projection sideways on classic scrollbars.
+    const rect = canvas.getBoundingClientRect();
+    pointer.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+    pointer.y = ((e.clientY - rect.top) / rect.height) * 2 - 1;
     pointerActive = e.clientY < window.innerHeight; // only while over the viewport
   }, { passive: true });
   window.addEventListener('pointerleave', () => { pointerActive = false; });

--- a/website/js/redesign/motion.js
+++ b/website/js/redesign/motion.js
@@ -4,27 +4,6 @@
 (() => {
   const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-  /* ---------- Telemetry ticker (cheap, runs even without GSAP) ---------- */
-  const telemetry = document.getElementById('telemetryLine');
-  if (telemetry && !reducedMotion) {
-    const lines = [
-      'region: us-east-1 · edge: cloudfront · state: nominal',
-      'pipeline: github-actions · deploys on merge',
-      'iac: terraform · everything reviewable',
-      'lambda: warm · dynamodb: pay-per-request',
-    ];
-    let i = 0;
-    setInterval(() => {
-      i = (i + 1) % lines.length;
-      telemetry.style.opacity = '0';
-      setTimeout(() => {
-        telemetry.textContent = lines[i];
-        telemetry.style.opacity = '0.85';
-      }, 300);
-    }, 4200);
-    telemetry.style.transition = 'opacity 0.3s ease';
-  }
-
   /* ---------- Custom cursor ---------- */
   const dot = document.getElementById('cursorDot');
   const finePointer = window.matchMedia('(hover: hover) and (pointer: fine)').matches;
@@ -186,10 +165,14 @@
     });
   });
 
+  // Reveal each card grid as one cohesive block. A per-card stagger made the
+  // first card settle ahead of its neighbours, so for ~1s card 01 floated
+  // above 02/03 and read as "off-centre". Moving the whole grid together keeps
+  // every card locked in the same plane — they can never look misaligned.
   document.querySelectorAll('.build-grid, .work-grid, .skill-clusters').forEach((grid) => {
-    gsap.from(grid.querySelectorAll('[data-anim="card"]'), {
-      y: 36, autoAlpha: 0, duration: 0.7, stagger: 0.12, ease: 'power3.out',
-      scrollTrigger: { trigger: grid, start: 'top 80%' },
+    gsap.from(grid, {
+      y: 28, autoAlpha: 0, duration: 0.75, ease: 'power3.out',
+      scrollTrigger: { trigger: grid, start: 'top 82%' },
     });
   });
 

--- a/website/js/redesign/terminal.js
+++ b/website/js/redesign/terminal.js
@@ -12,7 +12,8 @@
   const API_URL = window.SITE_CONFIG && window.SITE_CONFIG.TERMINAL_API_URL;
   const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-  const C = { ok: '#43ffa4', cyan: '#5ce1ff', dim: '#93a7b8', err: '#ff6666', signal: '#ff9e2c' };
+  // Single-accent palette: warm amber for prompts/headers, green for success only.
+  const C = { ok: '#43d6a0', cyan: '#ffc279', dim: '#93a7b8', err: '#ff6b6b', signal: '#ff9e2c' };
 
   function scrollToBottom() {
     terminalWrapper.scrollTo({ top: terminalWrapper.scrollHeight, behavior: reducedMotion ? 'auto' : 'smooth' });
@@ -210,7 +211,7 @@ Humans for judgment. Machines for repetition.`, C.ok),
     print('Wake up, Neo… (accent: joker)', '#ff8ae8');
   };
   localCommands['professional mode'] = () => {
-    setAccent('#00c3ff', '#5ce1ff');
+    setAccent('#ff9e2c', '#ffc279');
     print('Professional mode activated.', C.ok);
   };
 


### PR DESCRIPTION
## Summary

Refines the redesign onto a single confident signal: one amber accent over a near-black canvas, with green reserved strictly for live status. Strips decorative noise (HUD corners, telemetry clutter, gradient blobs) so typography and content carry the page.

- **Design system**: single-accent amber palette, tightened type scale, de-ornamented cards / terminal / pipeline. Curated spec documented in `design-system/MASTER.md`.
- **Card reveal fix**: card grids now animate in as one cohesive block. The previous per-card stagger let card 01 settle ~a second ahead of 02/03, so it floated above its neighbours mid-animation and read as "off-centre." Cards now move in lockstep and stay aligned through the whole entrance.
- **Hero graph**: neutral slate mesh carrying amber signals; reach-line projection now uses the canvas rect so scrollbar width never offsets the lines.
- **Terminal**: prompts/headers retinted amber, success messages green.
- **Copy & a11y**: tightened hero subhead, accessible brand `aria-label`, SVG favicon, SDE-led job title, rephrased footer colophon.

## Test plan

- [x] Hard-refresh and scroll the Capabilities section in; confirm cards 01/02/03 rise together and stay aligned
- [x] Verify hero graph reach-lines converge under the cursor
- [x] Confirm terminal `help` / `agents` / `status` render in the new palette
- [x] Lighthouse pass (perf / a11y / best-practices / SEO 95+)
- [x] Spot-check responsive layout at mobile / tablet / desktop widths
